### PR TITLE
feat: route new users to /setup FTUX page (issue #16)

### DIFF
--- a/src/app/(main)/accounts/page.jsx
+++ b/src/app/(main)/accounts/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import PageContainer from "../../../components/layout/PageContainer";
 import Button from "../../../components/ui/Button";
 import Card from "../../../components/ui/Card";
@@ -12,7 +13,6 @@ import NetWorthCard from "../../../components/dashboard/NetWorthCard";
 import { AssetsCard, LiabilitiesCard } from "../../../components/dashboard/AccountsSummaryCard";
 import { NetWorthHoverProvider } from "../../../components/dashboard/NetWorthHoverContext";
 import PlaidLinkModal from "../../../components/PlaidLinkModal";
-import AccountSetupFlow from "../../../components/ftux/AccountSetupFlow";
 
 // Helper to format currency
 const formatCurrency = (amount) => {
@@ -104,16 +104,25 @@ const CategoryHeader = ({ title, count, total, isFirst }) => {
 };
 
 export default function AccountsPage() {
+  const router = useRouter();
   const { profile } = useUser();
   const {
     accounts, // Institutions
     allAccounts, // Flat list of accounts
     loading,
+    initialized,
     error,
     refreshAccounts
   } = useAccounts();
 
   const [showLinkModal, setShowLinkModal] = useState(false);
+
+  // Redirect new users to setup page
+  useEffect(() => {
+    if (initialized && !loading && allAccounts.length === 0 && !error) {
+      router.replace("/setup");
+    }
+  }, [initialized, loading, allAccounts, error, router]);
 
   // Mobile carousel state
   const [activeCardIndex, setActiveCardIndex] = useState(0);
@@ -203,15 +212,9 @@ export default function AccountsPage() {
 
   const hasAccounts = allAccounts.length > 0;
 
-  if (!hasAccounts) {
-    const meta = profile || {};
-    const name = meta.first_name || undefined;
-
-    return (
-      <PageContainer title="Get started" showHeader={false}>
-        <AccountSetupFlow userName={name} onComplete={() => refreshAccounts()} />
-      </PageContainer>
-    );
+  // While redirecting (no accounts), render nothing
+  if (!hasAccounts && !error && !loading) {
+    return null;
   }
 
   return (

--- a/src/app/(main)/dashboard/page.jsx
+++ b/src/app/(main)/dashboard/page.jsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useUser } from "../../../components/providers/UserProvider";
 import { useAccounts } from "../../../components/providers/AccountsProvider";
 import PageContainer from "../../../components/layout/PageContainer";
-import AccountSetupFlow from "../../../components/ftux/AccountSetupFlow";
 import SpendingVsEarningCard from "../../../components/dashboard/SpendingVsEarningCard.jsx";
 import { dashboardLayout } from "../../../config/dashboardLayout";
 import MonthlyOverviewCard from "../../../components/dashboard/MonthlyOverviewCard";
@@ -35,8 +35,9 @@ const componentMap = {
 };
 
 export default function DashboardPage() {
+  const router = useRouter();
   const { user } = useUser();
-  const { accounts, loading: accountsLoading, initialized: accountsInitialized, refreshAccounts } = useAccounts();
+  const { accounts, loading: accountsLoading, initialized: accountsInitialized } = useAccounts();
   const [greeting, setGreeting] = useState("Dashboard");
   const [activeCardIndex, setActiveCardIndex] = useState(0);
 
@@ -105,17 +106,15 @@ export default function DashboardPage() {
 
   const hasInstitutions = accounts.length > 0;
 
-  if (accountsInitialized && !accountsLoading && !hasInstitutions) {
-    const meta = user?.user_metadata || {};
-    const first = meta.first_name || meta.name?.split(' ')[0] || meta.full_name?.split(' ')[0];
-    const nameFromEmail = user?.email?.split('@')[0];
-    const name = first || (nameFromEmail ? nameFromEmail.charAt(0).toUpperCase() + nameFromEmail.slice(1) : undefined);
+  useEffect(() => {
+    if (accountsInitialized && !accountsLoading && !hasInstitutions) {
+      router.replace("/setup");
+    }
+  }, [accountsInitialized, accountsLoading, hasInstitutions, router]);
 
-    return (
-      <PageContainer title="Get started" documentTitle="Get started" showHeader={false}>
-        <AccountSetupFlow userName={name} onComplete={() => refreshAccounts()} />
-      </PageContainer>
-    );
+  // Don't render the dashboard until we know the user has accounts
+  if (accountsInitialized && !accountsLoading && !hasInstitutions) {
+    return null;
   }
 
   return (

--- a/src/app/(main)/setup/page.jsx
+++ b/src/app/(main)/setup/page.jsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "../../../components/providers/UserProvider";
+import { useAccounts } from "../../../components/providers/AccountsProvider";
+import AccountSetupFlow from "../../../components/ftux/AccountSetupFlow";
+
+export default function SetupPage() {
+  const router = useRouter();
+  const { user, profile } = useUser();
+  const { accounts, loading: accountsLoading, initialized: accountsInitialized, refreshAccounts } = useAccounts();
+
+  // Guard: if user already has accounts, send them to dashboard
+  useEffect(() => {
+    if (accountsInitialized && !accountsLoading && accounts.length > 0) {
+      router.replace("/dashboard");
+    }
+  }, [accountsInitialized, accountsLoading, accounts, router]);
+
+  const handleComplete = async () => {
+    await refreshAccounts();
+    router.replace("/dashboard");
+  };
+
+  const meta = profile || user?.user_metadata || {};
+  const firstName =
+    meta.first_name ||
+    meta.name?.split(" ")[0] ||
+    meta.full_name?.split(" ")[0] ||
+    user?.email?.split("@")[0];
+  const name = firstName
+    ? firstName.charAt(0).toUpperCase() + firstName.slice(1)
+    : undefined;
+
+  return <AccountSetupFlow userName={name} onComplete={handleComplete} />;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -91,8 +91,10 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { accounts, loading, initialized } = useAccounts();
 
+  const isSetupRoute = pathname === "/setup";
   const isFtuxRoute = pathname === "/dashboard" || pathname === "/accounts";
-  const shouldUseFtuxShell = isFtuxRoute && initialized && !loading && accounts.length === 0;
+  const shouldUseFtuxShell =
+    isSetupRoute || (isFtuxRoute && initialized && !loading && accounts.length === 0);
 
   useEffect(() => {
     const handleResize = () => {


### PR DESCRIPTION
## Summary

Implements #16 — Route new users to a dedicated FTUX screen instead of the dashboard.

## Changes

### New: `src/app/(main)/setup/page.jsx`
- Dedicated full-screen FTUX page using the `FtuxShell` (clean layout, no sidebar)
- Renders `AccountSetupFlow` component
- Guards against users who already have accounts (redirects to `/dashboard`)
- On `onComplete`, refreshes accounts and redirects to `/dashboard`

### Updated: `src/app/(main)/dashboard/page.jsx`
- Removed inline `AccountSetupFlow` rendering
- Added `useEffect` that redirects to `/setup` when `accountsInitialized && !accountsLoading && accounts.length === 0`
- Returns `null` while redirect is in flight (no flash of dashboard content)

### Updated: `src/app/(main)/accounts/page.jsx`
- Same redirect pattern as dashboard
- Removed `AccountSetupFlow` import
- Returns `null` while redirecting

### Updated: `src/components/layout/AppShell.tsx`
- Added `/setup` to the routes that get `FtuxShell` (clean full-screen layout without sidebar)

## Acceptance Criteria Status

- ✅ New users are redirected to FTUX page (`/setup`) after login
- ✅ FTUX page uses `FtuxShell` — no sidebar, no dashboard provider cards
- ✅ Dashboard redirects to `/setup` if user has no accounts
- ✅ After connecting first account, `onComplete` refreshes accounts and navigates to `/dashboard`
- ✅ `/setup` guards against returning users (redirects to `/dashboard` if accounts exist)
- ✅ Build passes with zero errors