### PR TITLE
feat: simplify signup, add name collection to FTUX, restyle auth page

### DIFF
--- a/src/app/auth/page.jsx
+++ b/src/app/auth/page.jsx
@@ -20,7 +20,8 @@ export default function AuthPage() {
 
           <div className="mx-auto flex min-h-[calc(100vh-80px)] max-w-6xl flex-col px-5 sm:px-6 lg:px-8">
             <div className="flex flex-1 items-center py-10 lg:py-14">
-              <div className="grid w-full gap-12 lg:grid-cols-[minmax(0,1fr)_440px] lg:items-center">
+              <div className="grid w-full gap-16 lg:grid-cols-[minmax(0,1fr)_400px] lg:items-center">
+                {/* Left branding panel */}
                 <div className="max-w-2xl">
                   <p className="text-sm font-medium uppercase tracking-[0.18em] text-zinc-500">Personal finance, without the mess</p>
                   <h1 className="mt-4 text-4xl font-semibold tracking-tight text-zinc-900 sm:text-5xl">
@@ -31,25 +32,27 @@ export default function AuthPage() {
                   </p>
                 </div>
 
+                {/* Right form panel — open layout, no card */}
                 <div className="w-full max-w-md lg:ml-auto">
-                  <div className="space-y-4 rounded-xl border border-zinc-200 bg-white p-5 shadow-sm sm:p-6">
-                    <div>
-                      <h2 className="text-2xl font-semibold tracking-tight text-zinc-900">Welcome</h2>
-                      <p className="mt-2 text-sm leading-6 text-zinc-500">Use your email to sign in or create a new account.</p>
-                    </div>
-
-                    <Tabs
-                      tabs={[
-                        { key: "login", label: "Sign in", content: <LoginForm /> },
-                        { key: "signup", label: "Create account", content: <SignupForm /> },
-                      ]}
-                      initialKey="login"
-                      variant="zinc"
-                    />
+                  <div className="mb-6">
+                    <h2 className="text-2xl font-semibold tracking-tight text-zinc-900">Welcome</h2>
+                    <p className="mt-2 text-sm leading-6 text-zinc-500">Use your email to sign in or create a new account.</p>
                   </div>
 
-                  <p className="mt-5 text-center text-xs leading-5 text-zinc-400">
-                    By continuing, you agree to our <Link href="/docs/terms" className="underline underline-offset-4 hover:text-zinc-700">Terms</Link> and <Link href="/docs/privacy" className="underline underline-offset-4 hover:text-zinc-700">Privacy Policy</Link>.
+                  <Tabs
+                    tabs={[
+                      { key: "login", label: "Sign in", content: <LoginForm /> },
+                      { key: "signup", label: "Create account", content: <SignupForm /> },
+                    ]}
+                    initialKey="login"
+                    variant="zinc"
+                  />
+
+                  <p className="mt-6 text-xs leading-5 text-zinc-400">
+                    By continuing, you agree to our{" "}
+                    <Link href="/docs/terms" className="underline underline-offset-4 hover:text-zinc-700">Terms</Link>{" "}
+                    and{" "}
+                    <Link href="/docs/privacy" className="underline underline-offset-4 hover:text-zinc-700">Privacy Policy</Link>.
                   </p>
                 </div>
               </div>

--- a/src/components/auth/SignupForm.jsx
+++ b/src/components/auth/SignupForm.jsx
@@ -6,15 +6,12 @@ import Button from "../../components/ui/Button";
 import { supabase } from "../../lib/supabase/client";
 import { useToast } from "../../components/providers/ToastProvider";
 import { upsertUserProfile, buildAvatarUrl } from "../../lib/user/profile";
-import { capitalizeFirstOnly } from "../../lib/utils/formatName";
 import { FiEye, FiEyeOff } from "react-icons/fi";
 
 const inputClassName =
   "flex h-11 w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 transition-all outline-none focus:border-zinc-300 focus:ring-2 focus:ring-zinc-900/10 disabled:cursor-not-allowed disabled:opacity-50";
 
 export default function SignupForm() {
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -25,18 +22,7 @@ export default function SignupForm() {
   const onSubmit = async (e) => {
     e.preventDefault();
     setIsLoading(true);
-    const normalizedFirst = capitalizeFirstOnly(firstName);
-    const normalizedLast = capitalizeFirstOnly(lastName);
-    const { data, error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        data: {
-          first_name: normalizedFirst,
-          last_name: normalizedLast,
-        },
-      },
-    });
+    const { data, error } = await supabase.auth.signUp({ email, password });
 
     if (error) {
       setToast({ title: "Sign up failed", description: error.message, variant: "error" });
@@ -46,23 +32,13 @@ export default function SignupForm() {
         await upsertUserProfile({ avatar_url: avatarUrl });
       } catch {}
       setToast({ title: "Account created", variant: "success" });
-      router.push("/dashboard");
+      router.push("/setup");
     }
     setIsLoading(false);
   };
 
   return (
     <form onSubmit={onSubmit} className="space-y-4" noValidate>
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-zinc-800">First name</label>
-          <input className={inputClassName} type="text" placeholder="Jane" value={firstName} onChange={(e) => setFirstName(e.target.value)} required />
-        </div>
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-zinc-800">Last name</label>
-          <input className={inputClassName} type="text" placeholder="Doe" value={lastName} onChange={(e) => setLastName(e.target.value)} required />
-        </div>
-      </div>
       <div className="space-y-2">
         <label className="text-sm font-medium text-zinc-800">Email</label>
         <input className={inputClassName} type="email" placeholder="name@example.com" value={email} onChange={(e) => setEmail(e.target.value)} required />

--- a/src/components/ftux/AccountSetupFlow.jsx
+++ b/src/components/ftux/AccountSetupFlow.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { usePlaidLink } from "react-plaid-link";
 import { FiChevronRight, FiChevronLeft, FiCheck, FiAlertCircle, FiPlus } from "react-icons/fi";
@@ -8,6 +8,8 @@ import Button from "../ui/Button";
 import { useAccounts } from "../providers/AccountsProvider";
 import { authFetch } from "../../lib/api/fetch";
 import { capitalizeFirstOnly } from "../../lib/utils/formatName";
+import { upsertUserProfile } from "../../lib/user/profile";
+import { supabase } from "../../lib/supabase/client";
 
 const ACCOUNT_TYPES = [
   {
@@ -27,7 +29,8 @@ const ACCOUNT_TYPES = [
   },
 ];
 
-const TOTAL_STEPS = 4;
+// Now 5 steps: 0=Name, 1=Welcome, 2=AccountType, 3=Connecting, 4=Connected
+const TOTAL_STEPS = 5;
 
 const slideVariants = {
   enter: (direction) => ({
@@ -78,6 +81,100 @@ function BackButton({ onClick }) {
     >
       <FiChevronLeft className="h-4 w-4" />
     </motion.button>
+  );
+}
+
+const inputClassName =
+  "flex h-11 w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 transition-all outline-none focus:border-zinc-300 focus:ring-2 focus:ring-zinc-900/10 disabled:cursor-not-allowed disabled:opacity-50";
+
+/* ── Step 0: Name Collection ─────────────────────────────────── */
+function NameStep({ onNext }) {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const trimmedFirst = firstName.trim();
+    if (!trimmedFirst) return;
+
+    setSaving(true);
+    try {
+      const normalizedFirst = capitalizeFirstOnly(trimmedFirst);
+      const normalizedLast = capitalizeFirstOnly(lastName.trim());
+
+      // Save to auth metadata and user_profiles
+      await supabase.auth.updateUser({
+        data: {
+          first_name: normalizedFirst,
+          last_name: normalizedLast || null,
+        },
+      });
+
+      await upsertUserProfile({
+        first_name: normalizedFirst,
+        last_name: normalizedLast || null,
+      });
+
+      onNext(normalizedFirst);
+    } catch (err) {
+      console.error("[NameStep] save error", err);
+      // Still proceed — name can be set later
+      onNext(capitalizeFirstOnly(firstName.trim()));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center text-center w-full max-w-sm">
+      <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl">
+        What should we call you?
+      </h1>
+      <p className="mt-3 text-base text-zinc-500">We&apos;ll use this to personalize your experience.</p>
+
+      <form onSubmit={handleSubmit} className="mt-8 w-full space-y-3 text-left">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-zinc-800">First name</label>
+          <input
+            ref={inputRef}
+            className={inputClassName}
+            type="text"
+            placeholder="Jane"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-zinc-800">
+            Last name <span className="font-normal text-zinc-400">(optional)</span>
+          </label>
+          <input
+            className={inputClassName}
+            type="text"
+            placeholder="Doe"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+          />
+        </div>
+        <div className="pt-2">
+          <Button type="submit" fullWidth disabled={!firstName.trim() || saving} className="h-11">
+            {saving ? "Saving…" : (
+              <>
+                Continue
+                <FiChevronRight className="ml-1.5 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+    </div>
   );
 }
 
@@ -195,7 +292,6 @@ function ConnectingStep({ accountType, onSuccess, onError, onBack }) {
       setError(msg);
       onError(msg);
     } else {
-      // User closed Plaid without error — allow going back
       setPlaidExited(true);
     }
   };
@@ -206,7 +302,6 @@ function ConnectingStep({ accountType, onSuccess, onError, onBack }) {
     onExit: handlePlaidExit,
   });
 
-  // Fetch link token and connect
   useEffect(() => {
     let cancelled = false;
 
@@ -225,7 +320,6 @@ function ConnectingStep({ accountType, onSuccess, onError, onBack }) {
         if (cancelled) return;
 
         if (isMockPlaid) {
-          // In mock mode, skip Plaid Link entirely — exchange the mock token directly
           await exchangeToken(`mock-public-${accountType.id}`);
         } else {
           setLinkToken(data.link_token);
@@ -244,7 +338,6 @@ function ConnectingStep({ accountType, onSuccess, onError, onBack }) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accountType.id]);
 
-  // Open Plaid when ready (non-mock only)
   useEffect(() => {
     if (!isMockPlaid && linkToken && ready && !error && !plaidExited) {
       open();
@@ -334,7 +427,6 @@ function ConnectedStep({ plaidData, onAddMore, onComplete }) {
     <div className="flex flex-col items-center text-center">
       {/* Institution logo → dots → green checkmark */}
       <div className="mb-6 flex items-center gap-2">
-        {/* Institution logo or initial */}
         <motion.div
           initial={{ scale: 0, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
@@ -356,7 +448,6 @@ function ConnectedStep({ plaidData, onAddMore, onComplete }) {
           </div>
         </motion.div>
 
-        {/* Connecting dots */}
         {[0, 1, 2].map((i) => (
           <motion.div
             key={i}
@@ -367,7 +458,6 @@ function ConnectedStep({ plaidData, onAddMore, onComplete }) {
           />
         ))}
 
-        {/* Green checkmark */}
         <motion.div
           initial={{ scale: 0, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
@@ -387,7 +477,6 @@ function ConnectedStep({ plaidData, onAddMore, onComplete }) {
         {institution?.name ? `${institution.name} connected` : "Account connected"}
       </motion.h2>
 
-      {/* Connected accounts list */}
       {accounts.length > 0 && (
         <motion.div
           initial={{ opacity: 0, y: 10 }}
@@ -404,7 +493,6 @@ function ConnectedStep({ plaidData, onAddMore, onComplete }) {
                 transition={{ delay: 0.75 + i * 0.05 }}
                 className="flex items-center gap-3 px-4 py-3"
               >
-                {/* Institution logo with broken-image fallback */}
                 <div className="relative h-8 w-8 flex-shrink-0">
                   {institution?.logo && (
                     <img
@@ -475,29 +563,45 @@ export default function AccountSetupFlow({ userName, onComplete = null, onFlowSt
   const [direction, setDirection] = useState(1);
   const [selectedAccountType, setSelectedAccountType] = useState(null);
   const [plaidData, setPlaidData] = useState(null);
-
-  const firstName = useMemo(() => {
-    if (!userName) return "there";
+  // Resolved first name — either from props (returning user) or entered in step 0
+  const [resolvedFirstName, setResolvedFirstName] = useState(() => {
+    if (!userName) return null;
     return capitalizeFirstOnly(String(userName).split(" ")[0]);
-  }, [userName]);
+  });
+
+  // If we already have a name (returning user who somehow landed here), skip step 0
+  const effectiveStartStep = resolvedFirstName ? 1 : 0;
+  const [initialized, setInitialized] = useState(false);
+  useEffect(() => {
+    if (!initialized) {
+      if (resolvedFirstName) {
+        setStep(1);
+      }
+      setInitialized(true);
+    }
+  }, [resolvedFirstName, initialized]);
+
+  const firstName = resolvedFirstName || "there";
 
   const goTo = (nextStep) => {
     setDirection(nextStep > step ? 1 : -1);
     setStep(nextStep);
   };
 
+  const handleNameNext = (name) => {
+    setResolvedFirstName(name);
+    goTo(1);
+  };
+
   const handleAccountTypeSelect = (type) => {
     setSelectedAccountType(type);
-    // Signal to the parent (SetupPage) that the FTUX flow is now active.
-    // This prevents the redirect guard from firing when AccountsProvider
-    // refreshes after a successful account connection.
     onFlowStart?.();
-    goTo(2);
+    goTo(3);
   };
 
   const handlePlaidSuccess = (data) => {
     setPlaidData(data);
-    goTo(3);
+    goTo(4);
   };
 
   const handlePlaidError = () => {
@@ -506,7 +610,7 @@ export default function AccountSetupFlow({ userName, onComplete = null, onFlowSt
 
   const handleAddMore = () => {
     setSelectedAccountType(null);
-    goTo(1);
+    goTo(2);
   };
 
   const handleComplete = () => {
@@ -517,31 +621,38 @@ export default function AccountSetupFlow({ userName, onComplete = null, onFlowSt
     switch (step) {
       case 0:
         return (
-          <WelcomeStep
-            key="welcome"
-            firstName={firstName}
-            onNext={() => goTo(1)}
+          <NameStep
+            key="name"
+            onNext={handleNameNext}
           />
         );
       case 1:
         return (
-          <AccountTypeStep
-            key="account-type"
-            onSelect={handleAccountTypeSelect}
-            onBack={() => goTo(0)}
+          <WelcomeStep
+            key="welcome"
+            firstName={firstName}
+            onNext={() => goTo(2)}
           />
         );
       case 2:
+        return (
+          <AccountTypeStep
+            key="account-type"
+            onSelect={handleAccountTypeSelect}
+            onBack={() => goTo(1)}
+          />
+        );
+      case 3:
         return (
           <ConnectingStep
             key={`connecting-${selectedAccountType?.id}`}
             accountType={selectedAccountType}
             onSuccess={handlePlaidSuccess}
             onError={handlePlaidError}
-            onBack={() => goTo(1)}
+            onBack={() => goTo(2)}
           />
         );
-      case 3:
+      case 4:
         return (
           <ConnectedStep
             key="connected"

--- a/src/lib/user/profile.js
+++ b/src/lib/user/profile.js
@@ -48,7 +48,7 @@ export async function fetchUserProfile() {
   if (!userId) return { userId: null, profile: null };
   const { data, error } = await supabase
     .from("user_profiles")
-    .select("id, theme, accent_color, avatar_url")
+    .select("id, theme, accent_color, avatar_url, first_name, last_name")
     .eq("id", userId)
     .maybeSingle();
   if (error) return { userId, profile: null };

--- a/supabase/migrations/20260327000001_add_name_to_user_profiles.sql
+++ b/supabase/migrations/20260327000001_add_name_to_user_profiles.sql
@@ -1,0 +1,10 @@
+-- Add first_name and last_name columns to user_profiles
+-- Names are also stored in auth.users user_metadata for quick access,
+-- but having them in user_profiles allows easier server-side queries.
+
+alter table public.user_profiles
+  add column if not exists first_name text,
+  add column if not exists last_name text;
+
+comment on column public.user_profiles.first_name is 'User''s first name, collected during onboarding.';
+comment on column public.user_profiles.last_name is 'User''s last name, collected during onboarding (optional).';


### PR DESCRIPTION
## Summary

### 1. Simplified Create Account form
- Removed first name and last name fields from `SignupForm`
- Only email + password remain
- New accounts now redirect to `/setup` instead of `/dashboard` to collect name in onboarding

### 2. Name collection as first FTUX step
- Added new `NameStep` (step 0) to `AccountSetupFlow`
- Asks for first name (required) and last name (optional)
- Saves to Supabase auth user_metadata + user_profiles table
- Flows into existing welcome → account type → connect → connected steps
- Total steps bumped to 5; pagination dots updated
- Smart skip: if user already has a name (returning user), jumps straight to step 1

### 3. Restyled /auth page
- Removed card/border/shadow container around the form
- Form now sits in an open full-page layout matching the landing page aesthetic
- Kept the left-side branding panel and two-tab toggle (Sign In / Create Account)
- Cleaner, less modal-ish feel

### DB migration
- Added `first_name` and `last_name` columns to `user_profiles` table
- Updated `fetchUserProfile` select to include these fields