### PR TITLE
feat: restructure auth flow - sign-in only + FTUX account creation (#23)

### DIFF
--- a/src/app/(main)/layout.jsx
+++ b/src/app/(main)/layout.jsx
@@ -1,9 +1,17 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import AppShell from "../../components/layout/AppShell";
 import AuthGuard from "../../components/AuthGuard";
 
 export default function MainLayout({ children }) {
+  const pathname = usePathname();
+
+  // /setup handles its own auth state (step 0 is pre-auth account creation)
+  if (pathname === "/setup") {
+    return <AppShell>{children}</AppShell>;
+  }
+
   return (
     <AuthGuard>
       <AppShell>{children}</AppShell>

--- a/src/app/(main)/setup/page.jsx
+++ b/src/app/(main)/setup/page.jsx
@@ -1,43 +1,83 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useUser } from "../../../components/providers/UserProvider";
 import { useAccounts } from "../../../components/providers/AccountsProvider";
 import AccountSetupFlow from "../../../components/ftux/AccountSetupFlow";
 import { capitalizeFirstOnly } from "../../../lib/utils/formatName";
+import { supabase } from "../../../lib/supabase/client";
 
-export default function SetupPage() {
+function SetupContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user, profile } = useUser();
   const { accounts, loading: accountsLoading, initialized: accountsInitialized, refreshAccounts } = useAccounts();
   const [completing, setCompleting] = useState(false);
-  // Prevent redirect while the FTUX flow is actively connecting an account
+  const [initialStep, setInitialStep] = useState(null); // null = still resolving
   const flowActiveRef = useRef(false);
 
-  // Guard: redirect to dashboard if user already has accounts (returning user visiting /setup)
-  // Skip redirect for the first 500ms to avoid flash during initial load
-  const [settled, setSettled] = useState(false);
+  // Determine starting step for unauthenticated users
   useEffect(() => {
-    const timer = setTimeout(() => setSettled(true), 500);
-    return () => clearTimeout(timer);
+    async function resolveForUnauthenticated() {
+      const { data } = await supabase.auth.getUser();
+      const currentUser = data?.user;
+
+      if (!currentUser) {
+        // Not logged in → start at step 0 (create account)
+        setInitialStep(0);
+      }
+      // If authenticated, the next useEffect will handle it
+    }
+
+    resolveForUnauthenticated();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Once accounts are initialized and user is known, determine proper step
   useEffect(() => {
-    if (settled && accountsInitialized && !accountsLoading && accounts.length > 0 && !flowActiveRef.current) {
+    if (!user) return; // Not authenticated yet — step 0 is set above
+    if (initialStep !== null) return; // Already resolved
+
+    if (!accountsInitialized || accountsLoading) return;
+
+    if (accounts.length > 0 && !flowActiveRef.current) {
+      // User has accounts — onboarding complete, redirect to dashboard
       router.replace("/dashboard");
+      return;
     }
-  }, [settled, accountsInitialized, accountsLoading, accounts, router]);
+
+    // Check for step in URL query param (e.g. from login redirect)
+    const stepParam = searchParams.get("step");
+    const stepFromUrl = stepParam ? parseInt(stepParam, 10) : null;
+
+    if (stepFromUrl !== null && stepFromUrl >= 1 && stepFromUrl <= 4) {
+      setInitialStep(stepFromUrl);
+      return;
+    }
+
+    // Resume from saved onboarding_step in profile, or start at step 1 (name)
+    const savedStep = profile?.onboarding_step;
+    if (savedStep && savedStep >= 1 && savedStep <= 4) {
+      setInitialStep(savedStep);
+    } else {
+      setInitialStep(1); // Default to name step for authenticated users
+    }
+  }, [user, accountsInitialized, accountsLoading, accounts, profile, initialStep, router, searchParams]);
 
   const handleComplete = async () => {
     flowActiveRef.current = false;
     setCompleting(true);
+    // Mark onboarding as complete
+    try {
+      const { upsertUserProfile } = await import("../../../lib/user/profile");
+      await upsertUserProfile({ onboarding_step: null });
+    } catch {}
     await refreshAccounts();
     router.replace("/dashboard");
   };
 
-  // Don't render the setup flow while completing (after user clicks "Continue to dashboard")
-  if (completing) {
+  if (completing || initialStep === null) {
     return (
       <div className="flex h-full items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-900" />
@@ -45,8 +85,7 @@ export default function SetupPage() {
     );
   }
 
-  // Check profile and user_metadata independently — profile may be {} (empty object, truthy)
-  // even when the user has no DB row yet, so we can't rely on `profile || user_metadata`.
+  // Resolve display name for authenticated users resuming from step 1+
   const profileMeta = profile || {};
   const userMeta = user?.user_metadata || {};
   const firstName =
@@ -59,9 +98,24 @@ export default function SetupPage() {
 
   return (
     <AccountSetupFlow
-      userName={name}
+      initialStep={initialStep}
+      userName={initialStep >= 2 ? name : undefined}
       onComplete={handleComplete}
       onFlowStart={() => { flowActiveRef.current = true; }}
     />
+  );
+}
+
+export default function SetupPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full items-center justify-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-900" />
+        </div>
+      }
+    >
+      <SetupContent />
+    </Suspense>
   );
 }

--- a/src/app/auth/page.jsx
+++ b/src/app/auth/page.jsx
@@ -2,9 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import Tabs from "../../components/ui/Tabs";
 import LoginForm from "../../components/auth/LoginForm";
-import SignupForm from "../../components/auth/SignupForm";
 import PublicRoute from "../../components/PublicRoute";
 import RouteTransition from "../../components/RouteTransition";
 import { LandingNav } from "../page";
@@ -32,21 +30,21 @@ export default function AuthPage() {
                   </p>
                 </div>
 
-                {/* Right form panel — open layout, no card */}
+                {/* Right form panel */}
                 <div className="w-full max-w-md lg:ml-auto">
                   <div className="mb-6">
-                    <h2 className="text-2xl font-semibold tracking-tight text-zinc-900">Welcome</h2>
-                    <p className="mt-2 text-sm leading-6 text-zinc-500">Use your email to sign in or create a new account.</p>
+                    <h2 className="text-2xl font-semibold tracking-tight text-zinc-900">Welcome back</h2>
+                    <p className="mt-2 text-sm leading-6 text-zinc-500">Sign in to your account to continue.</p>
                   </div>
 
-                  <Tabs
-                    tabs={[
-                      { key: "login", label: "Sign in", content: <LoginForm /> },
-                      { key: "signup", label: "Create account", content: <SignupForm /> },
-                    ]}
-                    initialKey="login"
-                    variant="zinc"
-                  />
+                  <LoginForm />
+
+                  <p className="mt-5 text-sm text-zinc-500">
+                    Don&apos;t have an account?{" "}
+                    <Link href="/setup" className="font-medium text-zinc-900 underline underline-offset-4 hover:text-zinc-700">
+                      Get started →
+                    </Link>
+                  </p>
 
                   <p className="mt-6 text-xs leading-5 text-zinc-400">
                     By continuing, you agree to our{" "}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -180,7 +180,7 @@ export default function Home() {
 
             <div className="lp-fade-3 mt-10 flex flex-col items-center gap-4 sm:flex-row">
               <Link
-                href="/auth"
+                href="/setup"
                 className="inline-flex items-center justify-center rounded-md bg-zinc-900 px-8 py-3.5 text-sm font-medium text-white transition-colors hover:bg-zinc-800 cursor-pointer"
                 style={{ fontFamily: "var(--font-outfit)" }}
               >
@@ -264,11 +264,11 @@ export default function Home() {
               <div>
                 <div className="text-sm text-zinc-500">Ready to try it?</div>
                 <Link
-                  href="/auth"
+                  href="/setup"
                   className="mt-4 inline-flex h-11 cursor-pointer items-center justify-center rounded-md bg-zinc-900 px-5 text-sm font-medium text-white transition-colors hover:bg-zinc-800"
                   style={{ fontFamily: "var(--font-outfit)" }}
                 >
-                  Create account
+                  Get started
                 </Link>
               </div>
             </div>

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import Button from "../../components/ui/Button";
 import { supabase } from "../../lib/supabase/client";
 import { useToast } from "../../components/providers/ToastProvider";
@@ -17,7 +16,6 @@ export default function LoginForm() {
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { setToast } = useToast();
-  const router = useRouter();
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -26,9 +24,9 @@ export default function LoginForm() {
     if (error) {
       setToast({ title: "Sign in failed", description: error.message, variant: "error" });
       setIsLoading(false);
-    } else {
-      router.push("/dashboard");
     }
+    // On success, UserProvider's onAuthStateChange SIGNED_IN handler takes over:
+    // it checks for accounts and routes to /dashboard or /setup accordingly.
   };
 
   return (

--- a/src/components/ftux/AccountSetupFlow.jsx
+++ b/src/components/ftux/AccountSetupFlow.jsx
@@ -3,7 +3,8 @@
 import { useMemo, useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { usePlaidLink } from "react-plaid-link";
-import { FiChevronRight, FiChevronLeft, FiCheck, FiAlertCircle, FiPlus } from "react-icons/fi";
+import Link from "next/link";
+import { FiChevronRight, FiChevronLeft, FiCheck, FiAlertCircle, FiPlus, FiEye, FiEyeOff } from "react-icons/fi";
 import Button from "../ui/Button";
 import { useAccounts } from "../providers/AccountsProvider";
 import { authFetch } from "../../lib/api/fetch";
@@ -29,7 +30,7 @@ const ACCOUNT_TYPES = [
   },
 ];
 
-// Now 5 steps: 0=Name, 1=Welcome, 2=AccountType, 3=Connecting, 4=Connected
+// Steps: 0=Email+Password, 1=Name, 2=AccountType, 3=Connecting, 4=Connected
 const TOTAL_STEPS = 5;
 
 const slideVariants = {
@@ -87,8 +88,151 @@ function BackButton({ onClick }) {
 const inputClassName =
   "flex h-11 w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 placeholder:text-zinc-400 transition-all outline-none focus:border-zinc-300 focus:ring-2 focus:ring-zinc-900/10 disabled:cursor-not-allowed disabled:opacity-50";
 
-/* ── Step 0: Name Collection ─────────────────────────────────── */
-function NameStep({ onNext }) {
+/* ── Step 0: Email + Password (account creation) ─────────────── */
+function EmailPasswordStep({ onNext }) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const emailRef = useRef(null);
+
+  useEffect(() => {
+    emailRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { data, error: signUpError } = await supabase.auth.signUp({ email, password });
+
+      if (signUpError) {
+        // Supabase returns a generic error for duplicate emails in some configs
+        // but may also return user with identities=[] if email confirmation is off
+        const msg = signUpError.message || "";
+        if (
+          msg.toLowerCase().includes("already registered") ||
+          msg.toLowerCase().includes("user already exists") ||
+          msg.toLowerCase().includes("email address has already been registered")
+        ) {
+          setError("duplicate");
+        } else {
+          setError(msg || "Something went wrong. Please try again.");
+        }
+        setLoading(false);
+        return;
+      }
+
+      // Supabase may return a user with empty identities if email already exists
+      // (happens when email confirmation is disabled)
+      if (data?.user && (!data.user.identities || data.user.identities.length === 0)) {
+        setError("duplicate");
+        setLoading(false);
+        return;
+      }
+
+      if (data?.user) {
+        // Create initial profile with onboarding_step=1 (just completed step 0)
+        try {
+          const { buildAvatarUrl } = await import("../../lib/user/profile");
+          const avatarUrl = buildAvatarUrl(data.user.id, data.user.email);
+          await upsertUserProfile({ avatar_url: avatarUrl, onboarding_step: 1 });
+        } catch {}
+        onNext(email);
+      } else {
+        setError("Something went wrong. Please try again.");
+      }
+    } catch (err) {
+      setError(err?.message || "Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center text-center w-full max-w-sm">
+      <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl">
+        Create your account
+      </h1>
+      <p className="mt-3 text-base text-zinc-500">Get started with a free Zentari account.</p>
+
+      <form onSubmit={handleSubmit} className="mt-8 w-full space-y-3 text-left" noValidate>
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-zinc-800">Email</label>
+          <input
+            ref={emailRef}
+            className={inputClassName}
+            type="email"
+            placeholder="name@example.com"
+            value={email}
+            onChange={(e) => { setEmail(e.target.value); setError(null); }}
+            required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-zinc-800">Password</label>
+          <div className="relative">
+            <input
+              className={inputClassName}
+              type={showPassword ? "text" : "password"}
+              placeholder="At least 8 characters"
+              value={password}
+              onChange={(e) => { setPassword(e.target.value); setError(null); }}
+              required
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors"
+              tabIndex={-1}
+            >
+              {showPassword ? <FiEyeOff size={16} /> : <FiEye size={16} />}
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-md bg-red-50 border border-red-100 px-3 py-2.5 text-sm text-red-700">
+            {error === "duplicate" ? (
+              <>
+                This email is already registered.{" "}
+                <Link href="/auth" className="font-medium underline underline-offset-4 hover:text-red-900">
+                  Sign in instead →
+                </Link>
+              </>
+            ) : (
+              error
+            )}
+          </div>
+        )}
+
+        <div className="pt-2">
+          <Button type="submit" fullWidth disabled={!email.trim() || !password.trim() || loading} className="h-11">
+            {loading ? "Creating account…" : (
+              <>
+                Continue
+                <FiChevronRight className="ml-1.5 h-4 w-4" />
+              </>
+            )}
+          </Button>
+        </div>
+      </form>
+
+      <p className="mt-5 text-sm text-zinc-500">
+        Already have an account?{" "}
+        <Link href="/auth" className="font-medium text-zinc-900 underline underline-offset-4 hover:text-zinc-700">
+          Sign in →
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+/* ── Step 1: Name Collection ─────────────────────────────────── */
+function NameStep({ onNext, onBack }) {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [saving, setSaving] = useState(false);
@@ -119,6 +263,7 @@ function NameStep({ onNext }) {
       await upsertUserProfile({
         first_name: normalizedFirst,
         last_name: normalizedLast || null,
+        onboarding_step: 2,
       });
 
       onNext(normalizedFirst);
@@ -133,6 +278,11 @@ function NameStep({ onNext }) {
 
   return (
     <div className="flex flex-col items-center text-center w-full max-w-sm">
+      {onBack && (
+        <div className="mb-5 self-start">
+          <BackButton onClick={onBack} />
+        </div>
+      )}
       <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl">
         What should we call you?
       </h1>
@@ -178,25 +328,17 @@ function NameStep({ onNext }) {
   );
 }
 
-/* ── Step 1: Welcome ─────────────────────────────────────────── */
-function WelcomeStep({ firstName, onNext }) {
-  return (
-    <div className="flex flex-col items-center text-center">
-      <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl">
-        Hey {firstName},<br />let&apos;s get started.
-      </h1>
-      <p className="mt-4 text-base text-zinc-500">Connect your first account to get going.</p>
-      <Button onClick={onNext} className="mt-10 h-11 px-8 cursor-pointer">
-        Get started
-        <FiChevronRight className="ml-1.5 h-4 w-4" />
-      </Button>
-    </div>
-  );
-}
-
 /* ── Step 2: Account Type ────────────────────────────────────── */
 function AccountTypeStep({ onSelect, onBack }) {
   const [selected, setSelected] = useState(null);
+
+  const handleSelect = async (type) => {
+    // Save progress before Plaid opens
+    try {
+      await upsertUserProfile({ onboarding_step: 3 });
+    } catch {}
+    onSelect(type);
+  };
 
   return (
     <div className="w-full max-w-sm">
@@ -237,7 +379,7 @@ function AccountTypeStep({ onSelect, onBack }) {
       </div>
       <div className="mt-6">
         <Button
-          onClick={() => onSelect(selected)}
+          onClick={() => selected && handleSelect(selected)}
           disabled={!selected}
           className="w-full h-11"
         >
@@ -558,28 +700,24 @@ function ConnectedStep({ plaidData, onAddMore, onComplete }) {
 }
 
 /* ── Main component ─────────────────────────────────────────── */
-export default function AccountSetupFlow({ userName, onComplete = null, onFlowStart = null }) {
-  const [step, setStep] = useState(0);
+/**
+ * AccountSetupFlow
+ *
+ * Props:
+ *   initialStep   - which step to start on (0=email/pw, 1=name, 2=account type, 3=connecting, 4=connected)
+ *   userName      - pre-resolved first name (skips to the appropriate step if already named)
+ *   onComplete    - called when the user finishes the flow
+ *   onFlowStart   - called when Plaid link is about to open
+ */
+export default function AccountSetupFlow({ initialStep = 0, userName, onComplete = null, onFlowStart = null }) {
+  const [step, setStep] = useState(initialStep);
   const [direction, setDirection] = useState(1);
   const [selectedAccountType, setSelectedAccountType] = useState(null);
   const [plaidData, setPlaidData] = useState(null);
-  // Resolved first name — either from props (returning user) or entered in step 0
   const [resolvedFirstName, setResolvedFirstName] = useState(() => {
     if (!userName) return null;
     return capitalizeFirstOnly(String(userName).split(" ")[0]);
   });
-
-  // If we already have a name (returning user who somehow landed here), skip step 0
-  const effectiveStartStep = resolvedFirstName ? 1 : 0;
-  const [initialized, setInitialized] = useState(false);
-  useEffect(() => {
-    if (!initialized) {
-      if (resolvedFirstName) {
-        setStep(1);
-      }
-      setInitialized(true);
-    }
-  }, [resolvedFirstName, initialized]);
 
   const firstName = resolvedFirstName || "there";
 
@@ -588,9 +726,14 @@ export default function AccountSetupFlow({ userName, onComplete = null, onFlowSt
     setStep(nextStep);
   };
 
+  const handleEmailPasswordNext = (email) => {
+    // Account created, move to Name step
+    goTo(1);
+  };
+
   const handleNameNext = (name) => {
     setResolvedFirstName(name);
-    goTo(1);
+    goTo(2);
   };
 
   const handleAccountTypeSelect = (type) => {
@@ -621,17 +764,17 @@ export default function AccountSetupFlow({ userName, onComplete = null, onFlowSt
     switch (step) {
       case 0:
         return (
-          <NameStep
-            key="name"
-            onNext={handleNameNext}
+          <EmailPasswordStep
+            key="email-password"
+            onNext={handleEmailPasswordNext}
           />
         );
       case 1:
         return (
-          <WelcomeStep
-            key="welcome"
-            firstName={firstName}
-            onNext={() => goTo(2)}
+          <NameStep
+            key="name"
+            onNext={handleNameNext}
+            onBack={step > initialStep ? () => goTo(0) : null}
           />
         );
       case 2:

--- a/src/lib/user/profile.js
+++ b/src/lib/user/profile.js
@@ -48,7 +48,7 @@ export async function fetchUserProfile() {
   if (!userId) return { userId: null, profile: null };
   const { data, error } = await supabase
     .from("user_profiles")
-    .select("id, theme, accent_color, avatar_url, first_name, last_name")
+    .select("id, theme, accent_color, avatar_url, first_name, last_name, onboarding_step")
     .eq("id", userId)
     .maybeSingle();
   if (error) return { userId, profile: null };

--- a/supabase/migrations/20260327000002_add_onboarding_step_to_user_profiles.sql
+++ b/supabase/migrations/20260327000002_add_onboarding_step_to_user_profiles.sql
@@ -1,0 +1,9 @@
+-- Add onboarding_step column to user_profiles
+-- Tracks where the user left off in the FTUX onboarding flow so they can resume.
+-- Step values: 0=email/password (pre-auth), 1=name, 2=account type, 3=connecting, 4=connected
+-- NULL or absent means onboarding not started or already completed.
+
+alter table public.user_profiles
+  add column if not exists onboarding_step smallint;
+
+comment on column public.user_profiles.onboarding_step is 'Current FTUX onboarding step (1-4). NULL when onboarding is complete.';


### PR DESCRIPTION
Closes #23

## Summary

### 1. `/auth` page → sign-in only
- Removed Create Account tab entirely
- Clean single-purpose sign-in form
- Added "Don't have an account? Get started" link → `/setup`

### 2. FTUX `/setup` — full onboarding journey
- **Step 0:** Email + Password (creates Supabase account)
- **Step 1:** Name (first required, last optional)
- **Step 2:** Account types (what to connect)
- **Step 3:** Connect institution (Plaid link)
- **Step 4:** Connected → Dashboard

### 3. Duplicate email handling
Inline error on step 0: "This email is already registered. Sign in instead →" with link to `/auth`

### 4. Abandonment / resume
- `onboarding_step` tracked in `user_profiles` (new migration included)
- On sign-in, if onboarding incomplete, `UserProvider` routes to `/setup`; setup page reads saved step from profile
- `/setup` skips AuthGuard (step 0 is pre-auth); handles auth state itself
- On completion, marks `onboarding_step = null` in profile

### 5. Landing page CTAs
- "Get Started" button → `/setup`
- "Sign In" stays → `/auth`

## Validation
- `npx tsc --noEmit` — zero errors
- All pages return 200 on dev server