### PR TITLE
feat: dashboard cleanup — remove card wrappers, match FTUX minimal aesthetic

### DIFF
--- a/src/app/(main)/dashboard/page.jsx
+++ b/src/app/(main)/dashboard/page.jsx
@@ -47,6 +47,14 @@ export default function DashboardPage() {
     }
   }, [user]);
 
+  // Whether a component is a "main content" component (no card wrapper)
+  const mainContentComponents = new Set([
+    'MonthlyOverviewCard',
+    'SpendingVsEarningCard',
+    'TopCategoriesCard',
+    'RecentTransactionsCard',
+  ]);
+
   // Helper to render a single item (or row of items)
   const renderItem = (item) => {
     if (item.type === 'row') {
@@ -58,10 +66,11 @@ export default function DashboardPage() {
           {item.items.map((subItem) => {
             const Component = componentMap[subItem.component];
             if (!Component) return null;
+            const isMain = mainContentComponents.has(subItem.component);
             return (
               <div
                 key={subItem.id}
-                className={`${subItem.width || 'flex-1'} min-w-0 ${subItem.mobileHeight || ''}`}
+                className={`${subItem.width || 'flex-1'} min-w-0 ${subItem.mobileHeight || ''} ${isMain ? 'border-b border-zinc-100 pb-8 lg:border-b-0 lg:pb-0 lg:border-r lg:border-zinc-100 lg:pr-8 last:border-0 last:pb-0 last:pr-0' : ''}`}
               >
                 <Component {...(subItem.props || {})} />
               </div>

--- a/src/components/dashboard/BudgetsCard.jsx
+++ b/src/components/dashboard/BudgetsCard.jsx
@@ -53,7 +53,7 @@ export default function BudgetsCard() {
   // Loading state
   if (loading) {
     return (
-      <Card className="h-full flex flex-col">
+      <Card className="h-full flex flex-col bg-zinc-50/50 border border-zinc-100 shadow-none" variant="default">
         <div className="flex items-center justify-between mb-6">
           <h3 className="card-header">Budgets</h3>
         </div>
@@ -72,7 +72,7 @@ export default function BudgetsCard() {
   // Empty state - clean with prominent CTA
   if (budgets.length === 0) {
     return (
-      <Card className="h-full flex flex-col">
+      <Card className="h-full flex flex-col bg-zinc-50/50 border border-zinc-100 shadow-none" variant="default">
         <div className="mb-6">
           <h3 className="card-header">Budgets</h3>
         </div>
@@ -110,7 +110,7 @@ export default function BudgetsCard() {
   };
 
   return (
-    <Card hover className="h-full flex flex-col">
+    <Card hover className="h-full flex flex-col bg-zinc-50/50 border border-zinc-100 shadow-none" variant="default">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <h3 className="card-header">Budgets</h3>

--- a/src/components/dashboard/CalendarCard.jsx
+++ b/src/components/dashboard/CalendarCard.jsx
@@ -393,7 +393,7 @@ export default function CalendarCard({ className = '' }) {
 
   if (loading) {
     return (
-      <Card width="full" variant="glass" hover className={`flex flex-col ${className}`}>
+      <Card width="full" variant="default" hover className={`flex flex-col bg-zinc-50/50 border border-zinc-100 shadow-none ${className}`}>
         <div className="animate-pulse">
           {/* Header */}
           <div className="flex items-center justify-between mb-4">
@@ -424,7 +424,7 @@ export default function CalendarCard({ className = '' }) {
   }
 
   return (
-    <Card width="full" variant="glass" hover className={`flex flex-col ${className}`} allowOverflow>
+    <Card width="full" variant="default" hover className={`flex flex-col bg-zinc-50/50 border border-zinc-100 shadow-none ${className}`} allowOverflow>
 
       {/* Title Header */}
       <div className="flex items-center justify-between mb-4">

--- a/src/components/dashboard/MonthlyOverviewCard.jsx
+++ b/src/components/dashboard/MonthlyOverviewCard.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { authFetch } from "../../lib/api/fetch";
-import Card from "../ui/Card";
 import LineChart from "../ui/LineChart";
 import Dropdown from "../ui/Dropdown";
 import { useUser } from "../providers/UserProvider";
@@ -168,7 +167,7 @@ export default function MonthlyOverviewCard({ initialMonth, onBack }) {
   // Skeleton Loader Component
   const SkeletonLoader = () => (
     <div className="flex flex-col h-full animate-pulse">
-      <div className="px-6 pt-6">
+      <div className="pt-0">
         <div className="flex justify-between items-start mb-6">
           <div className="h-5 w-32 bg-[var(--color-border)] rounded" />
           <div className="h-5 w-24 bg-[var(--color-border)] rounded" />
@@ -184,19 +183,19 @@ export default function MonthlyOverviewCard({ initialMonth, onBack }) {
           </div>
         </div>
       </div>
-      <div className="flex-1 w-full bg-[var(--color-border)] opacity-30 mt-4 mx-6 rounded-lg" />
+      <div className="flex-1 w-full bg-[var(--color-border)] opacity-30 mt-4 rounded-lg" />
     </div>
   );
 
   return (
-    <Card padding="none" hover className="relative overflow-hidden h-full">
+    <div className="relative overflow-hidden h-full">
       {showLoading ? (
         <SkeletonLoader />
       ) : (
         <div className="flex flex-col h-full">
           {/* Custom Header */}
           {/* Custom Header */}
-          <div className="px-5 sm:px-8 pt-5 sm:pt-8 pb-3 flex justify-between items-start">
+          <div className="px-0 pt-0 pb-3 flex justify-between items-start">
             {/* Left Side: Title and Values */}
             <div>
               {/* Title */}
@@ -315,6 +314,6 @@ export default function MonthlyOverviewCard({ initialMonth, onBack }) {
           </div>
         </div>
       )}
-    </Card>
+    </div>
   );
 }

--- a/src/components/dashboard/RecentTransactionsCard.jsx
+++ b/src/components/dashboard/RecentTransactionsCard.jsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { authFetch } from '../../lib/api/fetch';
-import Card from '../ui/Card';
 import { useUser } from '../providers/UserProvider';
 import DynamicIcon from '../DynamicIcon';
 import { FiTag } from 'react-icons/fi';
@@ -146,7 +145,7 @@ export default function RecentTransactionsCard() {
 
   if (loading) {
     return (
-      <Card width="full" className="animate-pulse" variant="glass">
+      <div className="w-full animate-pulse">
         <div className="mb-4 flex justify-between items-center">
           <div className="h-4 bg-[var(--color-border)] rounded w-32" />
         </div>
@@ -161,21 +160,20 @@ export default function RecentTransactionsCard() {
             </div>
           ))}
         </div>
-      </Card>
+      </div>
     );
   }
 
   if (error) {
     return (
-      <Card width="full" variant="glass">
+      <div className="w-full">
         <div className="mb-4">
-          <div className="text-sm text-[var(--color-muted)] font-light">Recent Transactions</div>
-          <div className="text-lg font-light text-[var(--color-fg)]">Unable to load</div>
+          <div className="text-sm font-medium text-zinc-900">Recent Transactions</div>
         </div>
         <div className="pt-4">
           <div className="h-40 w-full flex items-center justify-center">
             <div className="text-center">
-              <div className="text-sm text-[var(--color-muted)] mb-2">
+              <div className="text-sm text-zinc-400 mb-2">
                 {error}
               </div>
               <button
@@ -187,61 +185,58 @@ export default function RecentTransactionsCard() {
             </div>
           </div>
         </div>
-      </Card>
+      </div>
     );
   }
 
   if (!transactions || transactions.length === 0) {
     return (
-      <Card width="full" variant="glass">
+      <div className="w-full">
         <div className="mb-4">
-          <div className="text-sm text-[var(--color-muted)] font-light">Recent Transactions</div>
-          <div className="text-lg font-light text-[var(--color-fg)]">No transactions</div>
+          <div className="text-sm font-medium text-zinc-900">Recent Transactions</div>
         </div>
         <div className="pt-4">
           <div className="h-40 w-full flex items-center justify-center">
             <div className="text-center">
-              <div className="text-sm text-[var(--color-muted)] mb-2">
+              <div className="text-sm text-zinc-400 mb-2">
                 No recent transactions found
               </div>
-              <div className="text-xs text-[var(--color-muted)]">
+              <div className="text-xs text-zinc-400">
                 Connect accounts to see your transaction history
               </div>
             </div>
           </div>
         </div>
-      </Card>
+      </div>
     );
   }
 
   return (
-    <Card width="full" variant="glass" hover>
+    <div className="w-full">
       <div className="mb-4 flex justify-between items-center">
-        <h3 className="card-header">Recent Transactions</h3>
-        <Link href="/transactions" className="text-xs text-[var(--color-muted)] hover:text-[var(--color-fg)] transition-colors">
+        <h3 className="text-sm font-semibold text-zinc-900">Recent Transactions</h3>
+        <Link href="/transactions" className="text-xs text-zinc-400 hover:text-zinc-600 transition-colors">
           View all
         </Link>
       </div>
 
-      <div className="space-y-1">
+      <div className="space-y-1 divide-y divide-zinc-100">
         {transactions.map((transaction, index) => {
           const isPositive = transaction.amount > 0;
-          // Use generic positive/neutral colors which map to neon in dark mode via CSS variables if configured,
-          // or explicit neon classes if we want to force it.
-          const amountColor = isPositive ? 'text-[var(--color-success)]' : 'text-[var(--color-fg)]';
+          const amountColor = isPositive ? 'text-[var(--color-success)]' : 'text-zinc-900';
 
           return (
             <div
               key={transaction.id || index}
-              className="flex items-center justify-between py-2 px-2 rounded-sm hover:bg-[var(--color-muted)]/5 transition-colors"
+              className="flex items-center justify-between py-2.5 px-1 hover:bg-zinc-50 transition-colors"
             >
-              <div className="flex items-center gap-2 min-w-0 flex-1">
+              <div className="flex items-center gap-3 min-w-0 flex-1">
                 <TransactionIconCircle transaction={transaction} />
                 <div className="min-w-0 flex-1 mr-4">
-                  <div className="text-sm font-light text-[var(--color-fg)] truncate">
+                  <div className="text-sm font-medium text-zinc-900 truncate">
                     {transaction.merchant_name || transaction.description || transaction.name || 'Transaction'}
                   </div>
-                  <div className="text-xs text-[var(--color-muted)] font-light">
+                  <div className="text-xs text-zinc-400">
                     {formatDate(transaction.date || transaction.datetime)}
                   </div>
                 </div>
@@ -251,7 +246,7 @@ export default function RecentTransactionsCard() {
                   {isPositive ? '+' : ''}{formatCurrency(transaction.amount)}
                 </div>
                 {transaction.pending && (
-                  <div className="text-xs text-[var(--color-muted)] italic font-light">
+                  <div className="text-xs text-zinc-400 italic">
                     Pending
                   </div>
                 )}
@@ -260,7 +255,6 @@ export default function RecentTransactionsCard() {
           );
         })}
       </div>
-
-    </Card>
+    </div>
   );
 }

--- a/src/components/dashboard/SpendingVsEarningCard.jsx
+++ b/src/components/dashboard/SpendingVsEarningCard.jsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useMemo, useEffect } from "react";
 import { authFetch } from "../../lib/api/fetch";
-import Card from "../ui/Card";
 import SpendingEarningChart from "./SpendingEarningChartV2";
 import Dropdown from "../ui/Dropdown";
 import { useUser } from "../providers/UserProvider";
@@ -176,9 +175,9 @@ export default function SpendingVsEarningCard() {
   const isPositiveCashflow = averageCashflow >= 0;
 
   return (
-    <Card padding="none" allowOverflow hover className="h-full relative" style={{ zIndex: hoveredData ? 100 : 'auto' }}>
+    <div className="h-full relative" style={{ zIndex: hoveredData ? 100 : 'auto' }}>
       {showLoading && (
-        <div className="absolute inset-0 z-20 animate-pulse pointer-events-none flex flex-col px-4 sm:px-6 pt-4 sm:pt-6 pb-0">
+        <div className="absolute inset-0 z-20 animate-pulse pointer-events-none flex flex-col pt-0 pb-0">
           {/* Header row — matches actual layout */}
           <div className="flex items-start justify-between gap-2 mb-2">
             <div className="min-w-0">
@@ -201,7 +200,7 @@ export default function SpendingVsEarningCard() {
 
       <div className={`h-full flex flex-col ${showLoading ? 'opacity-0' : ''}`}>
         {/* Custom Header */}
-        <div className="px-5 sm:px-8 pt-5 sm:pt-8 pb-2 shrink-0">
+        <div className="px-0 pt-0 pb-2 shrink-0">
           <div className="flex items-start justify-between gap-2">
             {/* Title and Values */}
             <div className="min-w-0">
@@ -256,6 +255,6 @@ export default function SpendingVsEarningCard() {
           />
         </div>
       </div>
-    </Card>
+    </div>
   );
 }

--- a/src/components/dashboard/TopCategoriesCard.jsx
+++ b/src/components/dashboard/TopCategoriesCard.jsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect, useMemo } from "react";
 import { authFetch } from "../../lib/api/fetch";
-import Card from "../ui/Card";
 import Dropdown from "../ui/Dropdown";
 import { useUser } from "../providers/UserProvider";
 import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
@@ -182,10 +181,10 @@ export default function TopCategoriesCard() {
 
   if (loading) {
     return (
-      <Card padding="none" className="h-[440px]">
+      <div className="h-[440px]">
         <div className="animate-pulse flex flex-col h-full">
           {/* Header */}
-          <div className="px-6 pt-6 pb-2 flex items-center justify-between">
+          <div className="pb-2 flex items-center justify-between">
             <div className="h-4 bg-[var(--color-border)] rounded w-32" />
             <div className="h-6 bg-[var(--color-border)] rounded w-24" />
           </div>
@@ -194,25 +193,25 @@ export default function TopCategoriesCard() {
             <div className="w-56 h-56 rounded-full border-[18px] border-[var(--color-border)] opacity-30" />
           </div>
         </div>
-      </Card>
+      </div>
     );
   }
 
   if (error) {
     return (
-      <Card className="h-[400px]">
-        <div className="h-full flex items-center justify-center text-[var(--color-muted)]">
+      <div className="h-[400px]">
+        <div className="h-full flex items-center justify-center text-zinc-400">
           Failed to load data
         </div>
-      </Card>
+      </div>
     );
   }
 
   return (
-    <Card padding="none" hover className="h-[440px] relative">
+    <div className="h-[440px] relative">
       <div ref={containerRef} className="flex flex-col h-full">
         {/* Custom Header with Dropdown */}
-        <div className="px-6 pt-8 pb-2 flex items-center justify-between">
+        <div className="pb-2 flex items-center justify-between">
           <div className="card-header">
             Top Spending
           </div>
@@ -305,6 +304,6 @@ export default function TopCategoriesCard() {
         </div>
         )}
       </div>
-    </Card>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #34

Removes glass-panel/Card wrappers from main dashboard content components and replaces with clean, minimal layout matching the FTUX `AccountSetupFlow` aesthetic.

## Changes

### Main content (Card wrappers removed)
- **MonthlyOverviewCard** — now renders as a plain `<div>`, no padding or glass effect. Skeleton loader updated accordingly.
- **SpendingVsEarningCard** — plain `<div>` wrapper, header padding removed to flush with section
- **TopCategoriesCard** — plain `<div>` wrapper across main, loading, and error states; error text updated to zinc-400
- **RecentTransactionsCard** — plain `<div>`, typography updated to `zinc-900` headings / `zinc-400` secondary text, row dividers via `divide-zinc-100`

### Sidebar widgets (subtle containment kept)
- **BudgetsCard** — Card kept but switched to `variant="default"` + `bg-zinc-50/50 border border-zinc-100 shadow-none` (no glass/backdrop-blur)
- **CalendarCard** — same treatment as BudgetsCard

### Dashboard page
- Cashflow row items get `border-zinc-100` dividers on mobile (border-b) and between items on desktop (border-r), providing breathing room without heavy card borders

## Verification
- `npx tsc --noEmit` — zero errors
- Dev server at `PORT=3001 npm run dev:test` — compiles and responds 200