### PR TITLE
feat: subscription tier system — free/pro enforcement + paywall UI

### DIFF
--- a/src/app/(main)/investments/page.jsx
+++ b/src/app/(main)/investments/page.jsx
@@ -6,6 +6,7 @@ import Card from "../../../components/ui/Card";
 import Button from "../../../components/ui/Button";
 import Modal from "../../../components/ui/Modal";
 import PlaidLinkModal from "../../../components/PlaidLinkModal";
+import UpgradeModal from "../../../components/UpgradeModal";
 import EmptyState from "../../../components/ui/EmptyState";
 import { PiBankFill } from "react-icons/pi";
 import { LuPlus } from "react-icons/lu";
@@ -178,7 +179,7 @@ function AnimatedCounter({ value, duration = 120 }) {
 // ============================================================================
 
 export default function InvestmentsPage() {
-  const { user, profile } = useUser();
+  const { user, profile, isPro } = useUser();
   const { setHeaderActions } = useInvestmentsHeader();
   const [investmentPortfolios, setInvestmentPortfolios] = useState([]);
   const [allHoldings, setAllHoldings] = useState([]);
@@ -186,6 +187,7 @@ export default function InvestmentsPage() {
   const [portfolioSnapshots, setPortfolioSnapshots] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showLinkModal, setShowLinkModal] = useState(false);
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [chartTimeRange, setChartTimeRange] = useState('ALL');
   const [sparklineData, setSparklineData] = useState({});
@@ -704,6 +706,28 @@ export default function InvestmentsPage() {
           <CardSkeleton className="h-48" />
         </div>
       </div>
+    );
+  }
+
+  // Free tier users: show upgrade prompt
+  if (!isPro) {
+    return (
+      <>
+        <EmptyState>
+          <EmptyState.Hero
+            layout="split"
+            title="Investments — Pro Feature"
+            description="Upgrade to Pro to connect your brokerage accounts and track your investment portfolio, holdings, and performance in real time."
+            action={
+              <Button size="lg" onClick={() => setShowUpgradeModal(true)} className="gap-2">
+                Upgrade to Pro
+              </Button>
+            }
+            preview={<InvestmentsPreviewMockup />}
+          />
+        </EmptyState>
+        <UpgradeModal isOpen={showUpgradeModal} onClose={() => setShowUpgradeModal(false)} />
+      </>
     );
   }
 

--- a/src/app/(main)/settings/page.jsx
+++ b/src/app/(main)/settings/page.jsx
@@ -17,11 +17,12 @@ import { HiChevronDown } from "react-icons/hi2";
 import { IoUnlink } from "react-icons/io5";
 import { FiTool } from "react-icons/fi";
 import PlaidLinkModal from "../../../components/PlaidLinkModal";
+import UpgradeModal from "../../../components/UpgradeModal";
 import { authFetch } from "../../../lib/api/fetch";
 
 export default function SettingsPage() {
   const router = useRouter();
-  const { logout, profile } = useUser();
+  const { logout, profile, isPro } = useUser();
   const { accounts, loading: accountsLoading, refreshAccounts } = useAccounts();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -29,6 +30,7 @@ export default function SettingsPage() {
   const [disconnectAccountModal, setDisconnectAccountModal] = useState({ isOpen: false, account: null, institution: null });
   const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [isPlaidModalOpen, setIsPlaidModalOpen] = useState(false);
+  const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
   const [isResyncing, setIsResyncing] = useState(false);
   const [expandedInstitutions, setExpandedInstitutions] = useState({});
 
@@ -186,6 +188,11 @@ export default function SettingsPage() {
   };
 
   const handleAddAccount = () => {
+    // Free users are limited to 1 connection — show upgrade modal if already connected
+    if (!isPro && accounts.length >= 1) {
+      setIsUpgradeModalOpen(true);
+      return;
+    }
     setIsPlaidModalOpen(true);
   };
 
@@ -497,6 +504,12 @@ export default function SettingsPage() {
       <PlaidLinkModal
         isOpen={isPlaidModalOpen}
         onClose={() => setIsPlaidModalOpen(false)}
+      />
+
+      {/* Upgrade Modal */}
+      <UpgradeModal
+        isOpen={isUpgradeModalOpen}
+        onClose={() => setIsUpgradeModalOpen(false)}
       />
     </PageContainer>
   );

--- a/src/app/api/plaid/link-token/route.js
+++ b/src/app/api/plaid/link-token/route.js
@@ -14,6 +14,16 @@ export async function POST(request) {
         { status: 404 }
       );
     }
+
+    // Fetch subscription tier
+    const { data: userProfile } = await supabaseAdmin
+      .from('user_profiles')
+      .select('subscription_tier')
+      .eq('id', userId)
+      .maybeSingle();
+    const subscriptionTier = userProfile?.subscription_tier || 'free';
+    const isPro = subscriptionTier === 'pro';
+
     // Update Mode: If plaidItemId is provided, we're requesting additional consent
     if (plaidItemId) {
       const { data: plaidItem, error: itemError } = await supabaseAdmin
@@ -38,9 +48,25 @@ export async function POST(request) {
         updateMode: true,
       });
     }
-    // Normal Mode: Always request both transactions and investments products
-    // This creates a single Plaid Item that covers all account types at an institution
-    const products = ['transactions', 'investments'];
+
+    // Normal Mode: enforce free tier limits
+    if (!isPro) {
+      // Check if user already has >= 1 plaid_item
+      const { data: existingItems, error: itemsError } = await supabaseAdmin
+        .from('plaid_items')
+        .select('id')
+        .eq('user_id', userId);
+
+      if (!itemsError && existingItems && existingItems.length >= 1) {
+        return Response.json(
+          { error: 'connection_limit' },
+          { status: 403 }
+        );
+      }
+    }
+
+    // Free: transactions only; Pro: transactions + investments
+    const products = isPro ? ['transactions', 'investments'] : ['transactions'];
     const linkTokenResponse = await createLinkToken(userId, products, null);
     return Response.json({
       link_token: linkTokenResponse.link_token,

--- a/src/app/api/plaid/recurring/sync/route.js
+++ b/src/app/api/plaid/recurring/sync/route.js
@@ -15,6 +15,16 @@ export async function POST(request) {
     const { userId: bodyUserId, forceReset = false } = await request.json();
     const userId = resolveUserId(request, bodyUserId);
 
+    // Check subscription tier — recurring is a Pro feature
+    const { data: userProfile } = await supabaseAdmin
+      .from('user_profiles')
+      .select('subscription_tier')
+      .eq('id', userId)
+      .maybeSingle();
+    if (!userProfile || userProfile.subscription_tier !== 'pro') {
+      return Response.json({ error: 'feature_locked', feature: 'recurring' }, { status: 403 });
+    }
+
     logger.info('Starting recurring transactions sync', { userId, forceReset });
 
     // If forceReset, delete all existing recurring streams for this user

--- a/src/app/api/recurring/get/route.js
+++ b/src/app/api/recurring/get/route.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { requireVerifiedUserId } from '../../../../lib/api/auth';
+import { supabaseAdmin } from '../../../../lib/supabase/admin';
 
 /**
  * GET /api/recurring/get
@@ -13,6 +14,17 @@ export async function GET(request) {
     if (err instanceof Response) return err;
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  // Check subscription tier — recurring is a Pro feature
+  const { data: userProfile } = await supabaseAdmin
+    .from('user_profiles')
+    .select('subscription_tier')
+    .eq('id', userId)
+    .maybeSingle();
+  if (!userProfile || userProfile.subscription_tier !== 'pro') {
+    return Response.json({ error: 'feature_locked', feature: 'recurring' }, { status: 403 });
+  }
+
   const { searchParams } = new URL(request.url);
   const streamType = searchParams.get('streamType'); // 'inflow', 'outflow', or null for all
 

--- a/src/app/api/subscription/upgrade/route.js
+++ b/src/app/api/subscription/upgrade/route.js
@@ -1,0 +1,40 @@
+import { supabaseAdmin } from '../../../../lib/supabase/admin';
+import { requireVerifiedUserId } from '../../../../lib/api/auth';
+
+/**
+ * POST /api/subscription/upgrade
+ * Sets subscription_tier to 'pro' for the authenticated user.
+ * Only available in non-production / mock mode.
+ */
+export async function POST(request) {
+  try {
+    const userId = requireVerifiedUserId(request);
+
+    // Guard: only works in non-production or mock Plaid environment
+    const isProduction = process.env.NODE_ENV === 'production';
+    const isMock = process.env.PLAID_ENV === 'mock';
+
+    if (isProduction && !isMock) {
+      return Response.json(
+        { error: 'Stripe not configured yet' },
+        { status: 400 }
+      );
+    }
+
+    const { error } = await supabaseAdmin
+      .from('user_profiles')
+      .update({ subscription_tier: 'pro' })
+      .eq('id', userId);
+
+    if (error) {
+      console.error('[subscription/upgrade] DB error:', error);
+      return Response.json({ error: 'Failed to upgrade subscription' }, { status: 500 });
+    }
+
+    return Response.json({ success: true, subscription_tier: 'pro' });
+  } catch (err) {
+    if (err instanceof Response) return err;
+    console.error('[subscription/upgrade] error:', err);
+    return Response.json({ error: err.message || 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/components/UpgradeModal.jsx
+++ b/src/components/UpgradeModal.jsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { FiCheck, FiX, FiZap } from "react-icons/fi";
+import { useUser } from "./providers/UserProvider";
+import { useToast } from "./providers/ToastProvider";
+import { authFetch } from "../lib/api/fetch";
+
+const PRO_FEATURES = [
+  "Unlimited bank connections",
+  "Investment portfolio tracking",
+  "Recurring transactions analysis",
+  "AI-powered financial insights",
+  "Priority support",
+];
+
+export default function UpgradeModal({ isOpen, onClose }) {
+  const { refreshProfile } = useUser();
+  const { setToast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleUpgrade = async () => {
+    setLoading(true);
+    try {
+      const res = await authFetch("/api/subscription/upgrade", { method: "POST" });
+      const body = await res.json();
+      if (!res.ok) {
+        setToast({
+          title: "Upgrade failed",
+          description: body.error || "Something went wrong",
+          variant: "error",
+        });
+        return;
+      }
+      await refreshProfile();
+      setToast({
+        title: "Welcome to Pro! 🎉",
+        description: "Your account has been upgraded to Pro.",
+        variant: "success",
+      });
+      onClose();
+    } catch (err) {
+      setToast({ title: "Upgrade failed", description: err.message, variant: "error" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative w-full max-w-sm bg-[var(--color-bg)] rounded-2xl shadow-xl border border-[var(--color-border)] overflow-hidden">
+        {/* Close button */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 p-1.5 rounded-lg text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-surface)] transition-colors"
+          aria-label="Close"
+        >
+          <FiX className="h-4 w-4" />
+        </button>
+
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 text-center">
+          <div className="inline-flex items-center justify-center h-12 w-12 rounded-full bg-[var(--color-accent)]/10 mb-4">
+            <FiZap className="h-6 w-6 text-[var(--color-accent)]" />
+          </div>
+          <h2 className="text-xl font-semibold text-[var(--color-fg)] tracking-tight">
+            Upgrade to Pro
+          </h2>
+          <p className="mt-1.5 text-sm text-[var(--color-muted)]">
+            Unlock the full power of your finances
+          </p>
+        </div>
+
+        {/* Divider */}
+        <div className="h-px mx-6 bg-[var(--color-border)]" />
+
+        {/* Feature list */}
+        <div className="px-6 py-4 space-y-3">
+          {PRO_FEATURES.map((feature) => (
+            <div key={feature} className="flex items-center gap-3">
+              <div className="flex-shrink-0 h-5 w-5 rounded-full bg-emerald-500/10 flex items-center justify-center">
+                <FiCheck className="h-3 w-3 text-emerald-500" strokeWidth={3} />
+              </div>
+              <span className="text-sm text-[var(--color-fg)]">{feature}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <div className="h-px mx-6 bg-[var(--color-border)]" />
+
+        {/* Pricing + CTA */}
+        <div className="px-6 py-5">
+          <div className="flex items-baseline gap-1 justify-center mb-4">
+            <span className="text-3xl font-bold text-[var(--color-fg)]">$9</span>
+            <span className="text-sm text-[var(--color-muted)]">/month</span>
+          </div>
+          <button
+            onClick={handleUpgrade}
+            disabled={loading}
+            className="w-full h-11 inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--color-accent)] text-white text-sm font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
+          >
+            {loading ? (
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+            ) : (
+              <>
+                <FiZap className="h-4 w-4" />
+                Upgrade Now
+              </>
+            )}
+          </button>
+          <p className="mt-3 text-center text-xs text-[var(--color-muted)]">
+            Cancel anytime. No hidden fees.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/RecurringTransactionsCard.jsx
+++ b/src/components/dashboard/RecurringTransactionsCard.jsx
@@ -5,9 +5,10 @@ import { authFetch } from '../../lib/api/fetch';
 import { usePlaidLink } from 'react-plaid-link';
 import Card from '../ui/Card';
 import { useUser } from '../providers/UserProvider';
-import { FiRefreshCw, FiAlertCircle, FiTag } from 'react-icons/fi';
+import { FiRefreshCw, FiAlertCircle, FiTag, FiLock } from 'react-icons/fi';
 import Drawer from '../ui/Drawer';
 import DynamicIcon from '../DynamicIcon';
+import UpgradeModal from '../UpgradeModal';
 
 function formatCurrency(amount) {
   return new Intl.NumberFormat('en-US', {
@@ -99,12 +100,13 @@ function getMonthlyAmount(amount, frequency) {
 }
 
 export default function RecurringTransactionsCard() {
-  const { user } = useUser();
+  const { user, isPro } = useUser();
   const [recurring, setRecurring] = useState([]);
   const [loading, setLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [error, setError] = useState(null);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
   const fetchRecurring = async () => {
     if (!user?.id) return;
@@ -275,6 +277,35 @@ export default function RecurringTransactionsCard() {
           <span className="text-xs">Click sync to fetch from your accounts.</span>
         </div>
       </Card>
+    );
+  }
+
+  // Free tier: show locked state
+  if (!isPro) {
+    return (
+      <>
+        <Card width="full" variant="glass" className="flex flex-col h-full">
+          <div className="flex items-center justify-between mb-6">
+            <h3 className="text-sm font-medium text-[var(--color-muted)]">Upcoming Bills</h3>
+          </div>
+          <div className="flex-1 flex flex-col items-center justify-center gap-3 py-4 text-center">
+            <div className="h-10 w-10 rounded-full bg-[var(--color-surface)] border border-[var(--color-border)] flex items-center justify-center">
+              <FiLock className="h-5 w-5 text-[var(--color-muted)]" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-[var(--color-fg)]">Pro Feature</p>
+              <p className="text-xs text-[var(--color-muted)] mt-0.5">Upgrade to track recurring bills</p>
+            </div>
+            <button
+              onClick={() => setShowUpgradeModal(true)}
+              className="mt-1 text-xs font-medium text-[var(--color-accent)] hover:opacity-80 transition-opacity cursor-pointer"
+            >
+              Upgrade to Pro →
+            </button>
+          </div>
+        </Card>
+        <UpgradeModal isOpen={showUpgradeModal} onClose={() => setShowUpgradeModal(false)} />
+      </>
     );
   }
 

--- a/src/components/ftux/AccountSetupFlow.jsx
+++ b/src/components/ftux/AccountSetupFlow.jsx
@@ -12,6 +12,8 @@ import { authFetch } from "../../lib/api/fetch";
 import { capitalizeFirstOnly } from "../../lib/utils/formatName";
 import { upsertUserProfile } from "../../lib/user/profile";
 import { supabase } from "../../lib/supabase/client";
+import { useUser } from "../providers/UserProvider";
+import UpgradeModal from "../UpgradeModal";
 
 // Steps: 0=Name, 1=Email+Password, 2=Connecting, 3=Connected
 const TOTAL_STEPS = 4;
@@ -671,10 +673,12 @@ function ConnectedStep({ plaidData, onAddMore, onComplete }) {
  *   onFlowStart   - called when Plaid link is about to open
  */
 export default function AccountSetupFlow({ initialStep = 0, userName, onComplete = null, onFlowStart = null }) {
+  const { isPro } = useUser();
   const [step, setStep] = useState(initialStep);
   const [direction, setDirection] = useState(1);
   const [plaidData, setPlaidData] = useState(null);
   const [pendingName, setPendingName] = useState(null);
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [resolvedFirstName, setResolvedFirstName] = useState(() => {
     if (!userName) return null;
     return capitalizeFirstOnly(String(userName).split(" ")[0]);
@@ -708,6 +712,11 @@ export default function AccountSetupFlow({ initialStep = 0, userName, onComplete
   };
 
   const handleAddMore = () => {
+    // Free users can only have 1 connection — show upgrade modal
+    if (!isPro) {
+      setShowUpgradeModal(true);
+      return;
+    }
     goTo(2);
   };
 
@@ -780,6 +789,12 @@ export default function AccountSetupFlow({ initialStep = 0, userName, onComplete
       <div className="mt-12">
         <PaginationDots current={step} total={TOTAL_STEPS} />
       </div>
+
+      {/* Upgrade Modal for free tier users */}
+      <UpgradeModal
+        isOpen={showUpgradeModal}
+        onClose={() => setShowUpgradeModal(false)}
+      />
 
       {/* "Already have an account?" — fixed bottom-right, visible on pre-auth steps */}
       <AnimatePresence>

--- a/src/components/providers/UserProvider.jsx
+++ b/src/components/providers/UserProvider.jsx
@@ -11,6 +11,8 @@ const UserContext = createContext({
   user: null,
   profile: null,
   loading: true,
+  isPro: false,
+  refreshProfile: async () => { },
   setTheme: (_theme) => { },
   setAccentColor: (_hexOrNull) => { },
   logout: () => { },
@@ -380,7 +382,9 @@ export default function UserProvider({ children }) {
     setUser(null);
   }, [applyTheme, applyAccent]);
 
-  const value = useMemo(() => ({ user, profile, loading, setTheme, setAccentColor, logout }), [user, profile, loading, setTheme, setAccentColor, logout]);
+  const isPro = profile?.subscription_tier === 'pro';
+
+  const value = useMemo(() => ({ user, profile, loading, isPro, refreshProfile, setTheme, setAccentColor, logout }), [user, profile, loading, isPro, refreshProfile, setTheme, setAccentColor, logout]);
 
   return (
     <UserContext.Provider value={value}>

--- a/src/lib/user/profile.js
+++ b/src/lib/user/profile.js
@@ -48,7 +48,7 @@ export async function fetchUserProfile() {
   if (!userId) return { userId: null, profile: null };
   const { data, error } = await supabase
     .from("user_profiles")
-    .select("id, theme, accent_color, avatar_url, first_name, last_name, onboarding_step")
+    .select("id, theme, accent_color, avatar_url, first_name, last_name, onboarding_step, subscription_tier")
     .eq("id", userId)
     .maybeSingle();
   if (error) return { userId, profile: null };


### PR DESCRIPTION
Closes #40

## Summary

Implements a full subscription tier system with free/pro enforcement and a paywall UI.

### Database
- Added `subscription_tier TEXT NOT NULL DEFAULT 'free'` column to `user_profiles`

### Profile & Context
- `profile.js`: includes `subscription_tier` in select
- `UserProvider`: exposes `isPro` boolean and `refreshProfile` in context

### API Enforcement
- `/api/plaid/link-token`: free users limited to 1 connection, transactions product only
- `/api/recurring/get`: returns 403 `feature_locked` for free users
- `/api/plaid/recurring/sync`: returns 403 `feature_locked` for free users
- `/api/subscription/upgrade` (new): sets tier to 'pro' — only works in non-prod/mock mode

### UI
- New `UpgradeModal` component: clean zinc-themed paywall with feature list, $9/month price, upgrade CTA
- **Settings page**: shows UpgradeModal instead of PlaidLinkModal when free user has >=1 connection
- **FTUX AccountSetupFlow**: shows UpgradeModal when free user clicks 'Connect another account'
- **Investments page**: shows full-page upgrade prompt for free tier users
- **RecurringTransactionsCard**: shows locked state with 'Upgrade to Pro' link

### Validation
- `npx tsc --noEmit` zero errors
- Dev server boots and serves HTML successfully