### PR TITLE
Fix subscription tier UX — upgrade modal polish, PlaidLink 403, CalendarCard free tier

### DIFF
--- a/src/app/(main)/settings/page.jsx
+++ b/src/app/(main)/settings/page.jsx
@@ -504,6 +504,10 @@ export default function SettingsPage() {
       <PlaidLinkModal
         isOpen={isPlaidModalOpen}
         onClose={() => setIsPlaidModalOpen(false)}
+        onUpgradeNeeded={() => {
+          setIsPlaidModalOpen(false);
+          setIsUpgradeModalOpen(true);
+        }}
       />
 
       {/* Upgrade Modal */}

--- a/src/components/PlaidLinkModal.jsx
+++ b/src/components/PlaidLinkModal.jsx
@@ -12,7 +12,7 @@ import { authFetch } from '../lib/api/fetch';
 
 const isMockPlaid = process.env.NEXT_PUBLIC_PLAID_ENV === 'mock';
 
-export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCallback = null }) {
+export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCallback = null, onUpgradeNeeded = null }) {
   const { user } = useUser();
   const { addAccount, refreshAccounts } = useAccounts();
   const [linkToken, setLinkToken] = useState(null);
@@ -107,7 +107,14 @@ export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCa
       });
 
       if (!response.ok) {
-        throw new Error('Failed to create link token');
+        const errorBody = await response.json().catch(() => ({}));
+        if (response.status === 403 && errorBody.error === 'connection_limit') {
+          setLoading(false);
+          onClose();
+          onUpgradeNeeded?.();
+          return;
+        }
+        throw new Error(errorBody.error || 'Failed to create link token');
       }
 
       const data = await response.json();

--- a/src/components/UpgradeModal.jsx
+++ b/src/components/UpgradeModal.jsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { FiCheck, FiX, FiZap } from "react-icons/fi";
+import { AnimatePresence, motion } from "framer-motion";
+import { FiCheck, FiX } from "react-icons/fi";
+import { HiSparkles } from "react-icons/hi2";
 import { useUser } from "./providers/UserProvider";
 import { useToast } from "./providers/ToastProvider";
 import { authFetch } from "../lib/api/fetch";
@@ -18,8 +20,6 @@ export default function UpgradeModal({ isOpen, onClose }) {
   const { refreshProfile } = useUser();
   const { setToast } = useToast();
   const [loading, setLoading] = useState(false);
-
-  if (!isOpen) return null;
 
   const handleUpgrade = async () => {
     setLoading(true);
@@ -49,80 +49,94 @@ export default function UpgradeModal({ isOpen, onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
-        onClick={onClose}
-      />
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          {/* Backdrop */}
+          <motion.div
+            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          />
 
-      {/* Modal */}
-      <div className="relative w-full max-w-sm bg-[var(--color-bg)] rounded-2xl shadow-xl border border-[var(--color-border)] overflow-hidden">
-        {/* Close button */}
-        <button
-          onClick={onClose}
-          className="absolute top-4 right-4 p-1.5 rounded-lg text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-surface)] transition-colors"
-          aria-label="Close"
-        >
-          <FiX className="h-4 w-4" />
-        </button>
-
-        {/* Header */}
-        <div className="px-6 pt-6 pb-4 text-center">
-          <div className="inline-flex items-center justify-center h-12 w-12 rounded-full bg-[var(--color-accent)]/10 mb-4">
-            <FiZap className="h-6 w-6 text-[var(--color-accent)]" />
-          </div>
-          <h2 className="text-xl font-semibold text-[var(--color-fg)] tracking-tight">
-            Upgrade to Pro
-          </h2>
-          <p className="mt-1.5 text-sm text-[var(--color-muted)]">
-            Unlock the full power of your finances
-          </p>
-        </div>
-
-        {/* Divider */}
-        <div className="h-px mx-6 bg-[var(--color-border)]" />
-
-        {/* Feature list */}
-        <div className="px-6 py-4 space-y-3">
-          {PRO_FEATURES.map((feature) => (
-            <div key={feature} className="flex items-center gap-3">
-              <div className="flex-shrink-0 h-5 w-5 rounded-full bg-emerald-500/10 flex items-center justify-center">
-                <FiCheck className="h-3 w-3 text-emerald-500" strokeWidth={3} />
-              </div>
-              <span className="text-sm text-[var(--color-fg)]">{feature}</span>
-            </div>
-          ))}
-        </div>
-
-        {/* Divider */}
-        <div className="h-px mx-6 bg-[var(--color-border)]" />
-
-        {/* Pricing + CTA */}
-        <div className="px-6 py-5">
-          <div className="flex items-baseline gap-1 justify-center mb-4">
-            <span className="text-3xl font-bold text-[var(--color-fg)]">$9</span>
-            <span className="text-sm text-[var(--color-muted)]">/month</span>
-          </div>
-          <button
-            onClick={handleUpgrade}
-            disabled={loading}
-            className="w-full h-11 inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--color-accent)] text-white text-sm font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
+          {/* Modal */}
+          <motion.div
+            className="relative w-full max-w-sm bg-[var(--color-bg)] rounded-2xl shadow-xl border border-[var(--color-border)] overflow-hidden"
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.95 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
           >
-            {loading ? (
-              <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-            ) : (
-              <>
-                <FiZap className="h-4 w-4" />
-                Upgrade Now
-              </>
-            )}
-          </button>
-          <p className="mt-3 text-center text-xs text-[var(--color-muted)]">
-            Cancel anytime. No hidden fees.
-          </p>
+            {/* Close button */}
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 p-1.5 rounded-lg text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-surface)] transition-colors"
+              aria-label="Close"
+            >
+              <FiX className="h-4 w-4" />
+            </button>
+
+            {/* Header */}
+            <div className="px-6 pt-6 pb-4 text-center">
+              <div className="inline-flex items-center justify-center h-12 w-12 rounded-full bg-[var(--color-accent)]/10 mb-4">
+                <HiSparkles className="h-6 w-6 text-[var(--color-accent)]" />
+              </div>
+              <h2 className="text-xl font-semibold text-[var(--color-fg)] tracking-tight">
+                Upgrade to Pro
+              </h2>
+              <p className="mt-1.5 text-sm text-[var(--color-muted)]">
+                Unlock the full power of your finances
+              </p>
+            </div>
+
+            {/* Divider */}
+            <div className="h-px mx-6 bg-[var(--color-border)]" />
+
+            {/* Feature list */}
+            <div className="px-6 py-4 space-y-3">
+              {PRO_FEATURES.map((feature) => (
+                <div key={feature} className="flex items-center gap-3">
+                  <div className="flex-shrink-0 h-5 w-5 rounded-full bg-emerald-500/10 flex items-center justify-center">
+                    <FiCheck className="h-3 w-3 text-emerald-500" strokeWidth={3} />
+                  </div>
+                  <span className="text-sm text-[var(--color-fg)]">{feature}</span>
+                </div>
+              ))}
+            </div>
+
+            {/* Divider */}
+            <div className="h-px mx-6 bg-[var(--color-border)]" />
+
+            {/* Pricing + CTA */}
+            <div className="px-6 py-5">
+              <div className="flex items-baseline gap-1 justify-center mb-4">
+                <span className="text-3xl font-bold text-[var(--color-fg)]">$9</span>
+                <span className="text-sm text-[var(--color-muted)]">/month</span>
+              </div>
+              <button
+                onClick={handleUpgrade}
+                disabled={loading}
+                className="w-full h-11 inline-flex items-center justify-center gap-2 rounded-xl bg-[var(--color-accent)] text-white text-sm font-medium hover:opacity-90 active:scale-[0.98] transition-all duration-150 disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
+              >
+                {loading ? (
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                ) : (
+                  <>
+                    <HiSparkles className="h-4 w-4" />
+                    Upgrade Now
+                  </>
+                )}
+              </button>
+              <p className="mt-3 text-center text-xs text-[var(--color-muted)]">
+                Cancel anytime. No hidden fees.
+              </p>
+            </div>
+          </motion.div>
         </div>
-      </div>
-    </div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/src/components/dashboard/CalendarCard.jsx
+++ b/src/components/dashboard/CalendarCard.jsx
@@ -144,7 +144,7 @@ const getOccurrencesForMonth = (stream, year, month) => {
 };
 
 export default function CalendarCard({ className = '' }) {
-  const { user } = useUser();
+  const { user, isPro } = useUser();
   const today = new Date();
   const [currentMonth, setCurrentMonth] = useState(today.getMonth());
   const [currentYear, setCurrentYear] = useState(today.getFullYear());
@@ -174,10 +174,15 @@ export default function CalendarCard({ className = '' }) {
     });
   };
 
-  // Fetch recurring streams
+  // Fetch recurring streams (Pro only)
   useEffect(() => {
     const fetchRecurring = async () => {
       if (!user?.id) return;
+      if (!isPro) {
+        setRecurring([]);
+        setLoading(false);
+        return;
+      }
       try {
         setLoading(true);
         // Fetch all recurring streams (both inflow and outflow) by removing streamType filter
@@ -192,7 +197,7 @@ export default function CalendarCard({ className = '' }) {
       }
     };
     fetchRecurring();
-  }, [user?.id]);
+  }, [user?.id, isPro]);
 
   // Build calendar grid
   const calendarDays = useMemo(() => {
@@ -653,7 +658,11 @@ export default function CalendarCard({ className = '' }) {
 
           {recurring.length === 0 && (
             <div className="text-center py-10 text-[var(--color-muted)]">
-              No recurring transactions found
+              {isPro ? 'No recurring transactions found' : (
+                <span className="text-xs text-[var(--color-muted)]">
+                  Upgrade to Pro to see recurring transactions
+                </span>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

Closes #42

### Changes

**1. UpgradeModal polish**
- Replaced `FiZap` with `HiSparkles` (more premium feel)
- Added framer-motion `AnimatePresence` with:
  - Backdrop: fade in/out
  - Modal card: scale 0.95→1 + fade in, reverse on exit
- Restructured to use `AnimatePresence` conditional render pattern

**2. PlaidLinkModal 403 handling**
- Parses JSON body before throwing on non-ok response
- If status 403 + `body.error === 'connection_limit'`: closes modal, calls `onUpgradeNeeded()` (no error toast)
- `settings/page.jsx`: `onUpgradeNeeded` opens UpgradeModal

**3. CalendarCard free tier fix**
- Reads `isPro` from `useUser`
- Skips `/api/recurring/get` entirely for free users (no more 403)
- Calendar still renders for current date visibility
- Drawer shows subtle 'Upgrade to Pro to see recurring transactions' hint for free users

### Validation
- `npx tsc --noEmit` — clean (no errors)
- Dev server starts successfully