### PR TITLE
feat: production Google OAuth only auth (#54)

### DIFF
--- a/data/tasks/finance-next/54/active-session.json
+++ b/data/tasks/finance-next/54/active-session.json
@@ -1,0 +1,5 @@
+{
+  "agent": "bibi",
+  "startedAt": "2026-03-28T16:42:18Z",
+  "sessionId": "agent:bibi:subagent:4226754c-c5fd-41a9-9e47-1b283ac87049"
+}

--- a/src/app/auth/page.jsx
+++ b/src/app/auth/page.jsx
@@ -7,6 +7,8 @@ import PublicRoute from "../../components/PublicRoute";
 import RouteTransition from "../../components/RouteTransition";
 import { LandingNav } from "../page";
 
+const isMock = process.env.NEXT_PUBLIC_PLAID_ENV === "mock";
+
 export default function AuthPage() {
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -39,12 +41,14 @@ export default function AuthPage() {
 
                   <LoginForm />
 
-                  <p className="mt-5 text-sm text-zinc-500">
-                    Don&apos;t have an account?{" "}
-                    <Link href="/setup" className="font-medium text-zinc-900 underline underline-offset-4 hover:text-zinc-700">
-                      Get started
-                    </Link>
-                  </p>
+                  {isMock && (
+                    <p className="mt-5 text-sm text-zinc-500">
+                      Don&apos;t have an account?{" "}
+                      <Link href="/setup" className="font-medium text-zinc-900 underline underline-offset-4 hover:text-zinc-700">
+                        Get started
+                      </Link>
+                    </p>
+                  )}
 
                   <p className="mt-6 text-xs leading-5 text-zinc-400">
                     By continuing, you agree to our{" "}

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -10,12 +10,58 @@ import { FiEye, FiEyeOff } from "react-icons/fi";
 const inputClassName =
   "flex h-11 w-full rounded-lg border-0 bg-zinc-200/50 px-4 py-2 text-sm font-medium text-zinc-900 placeholder:text-zinc-400 placeholder:font-normal transition-all outline-none focus:outline-none focus:ring-0 focus:border-transparent focus:bg-zinc-200/70 disabled:cursor-not-allowed disabled:opacity-50";
 
+const isMock = process.env.NEXT_PUBLIC_PLAID_ENV === "mock";
+
+// Google "G" logo SVG
+function GoogleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
+      <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+      <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+      <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+      <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+      <path fill="none" d="M0 0h48v48H0z"/>
+    </svg>
+  );
+}
+
+function GoogleSignInButton({ loading, onClick, label = "Sign in with Google" }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={loading}
+      className="flex h-11 w-full items-center justify-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 text-sm font-medium text-zinc-800 shadow-none transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <GoogleIcon />
+      {loading ? "Redirecting…" : label}
+    </button>
+  );
+}
+
+export { GoogleSignInButton, GoogleIcon };
+
 export default function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { setToast } = useToast();
+
+  const handleGoogleSignIn = async () => {
+    setIsLoading(true);
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback/exchange?next=/setup`,
+      },
+    });
+    if (error) {
+      setToast({ title: "Sign in failed", description: error.message, variant: "error" });
+      setIsLoading(false);
+    }
+    // On success, browser will redirect to Google OAuth
+  };
 
   const onSubmit = async (e) => {
     e.preventDefault();
@@ -28,6 +74,10 @@ export default function LoginForm() {
     // On success, UserProvider's onAuthStateChange SIGNED_IN handler takes over:
     // it checks for accounts and routes to /dashboard or /setup accordingly.
   };
+
+  if (!isMock) {
+    return <GoogleSignInButton loading={isLoading} onClick={handleGoogleSignIn} />;
+  }
 
   return (
     <form onSubmit={onSubmit} className="space-y-5" noValidate>

--- a/src/components/ftux/AccountSetupFlow.jsx
+++ b/src/components/ftux/AccountSetupFlow.jsx
@@ -12,10 +12,12 @@ import { authFetch } from "../../lib/api/fetch";
 import { capitalizeFirstOnly } from "../../lib/utils/formatName";
 import { upsertUserProfile } from "../../lib/user/profile";
 import { supabase } from "../../lib/supabase/client";
-
+import { GoogleSignInButton } from "../auth/LoginForm";
 
 // Steps: 0=Name, 1=Email+Password, 2=Connecting, 3=Connected
-const TOTAL_STEPS = 4;
+// In production (non-mock): steps 0+1 are skipped; only 2=Connecting, 3=Connected
+const isMockEnv = process.env.NEXT_PUBLIC_PLAID_ENV === "mock";
+const TOTAL_STEPS = isMockEnv ? 4 : 2;
 
 const slideVariants = {
   enter: (direction) => ({
@@ -326,7 +328,7 @@ function EmailPasswordStep({ onNext, onBack, pendingName }) {
 }
 
 /* ── Step 2: Connecting (uses Plaid) ────────────────────────── */
-const isMockPlaid = process.env.NEXT_PUBLIC_PLAID_ENV === "mock";
+const isMockPlaid = isMockEnv;
 
 function ConnectingStep({ onSuccess, onError, onBack }) {
   const { addAccount, refreshAccounts } = useAccounts();
@@ -645,15 +647,53 @@ function ConnectedStep({ plaidData, onComplete }) {
   );
 }
 
+/* ── Production: Google sign-up gate (pre-auth) ─────────────── */
+function GoogleSignUpGate() {
+  const [loading, setLoading] = useState(false);
+
+  const handleGoogleSignUp = async () => {
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback/exchange?next=/setup`,
+      },
+    });
+    if (error) {
+      console.error("[GoogleSignUpGate] OAuth error", error);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center text-center w-full max-w-sm">
+      <h1 className="text-xl font-semibold tracking-tight text-zinc-900">
+        Create your account
+      </h1>
+      <p className="mt-2 text-sm text-zinc-500">
+        Sign up with Google to get started in seconds.
+      </p>
+      <div className="mt-8 w-full">
+        <GoogleSignInButton loading={loading} onClick={handleGoogleSignUp} label="Sign up with Google" />
+      </div>
+    </div>
+  );
+}
+
 /* ── Main component ─────────────────────────────────────────── */
 /**
  * AccountSetupFlow
  *
  * Props:
- *   initialStep   - which step to start on (0=name, 1=email/pw, 2=account type, 3=connecting, 4=connected)
+ *   initialStep   - which step to start on (0=name, 1=email/pw, 2=connecting, 3=connected)
  *   userName      - pre-resolved first name (used when resuming from step 2+)
  *   onComplete    - called when the user finishes the flow
  *   onFlowStart   - called when Plaid link is about to open
+ *
+ * Production mode (NEXT_PUBLIC_PLAID_ENV !== 'mock'):
+ *   - Steps 0 & 1 replaced with Google OAuth gate
+ *   - Authenticated users land directly at step 2 (Plaid connection)
+ *   - Pagination shows 2 dots: connect + connected
  */
 export default function AccountSetupFlow({ initialStep = 0, userName, onComplete = null, onFlowStart = null }) {
   const [step, setStep] = useState(initialStep);
@@ -697,6 +737,11 @@ export default function AccountSetupFlow({ initialStep = 0, userName, onComplete
   };
 
   const stepContent = () => {
+    // Production mode: steps 0 and 1 replaced by Google OAuth gate
+    if (!isMockEnv && step <= 1) {
+      return <GoogleSignUpGate key="google-signup" />;
+    }
+
     switch (step) {
       case 0:
         return (
@@ -720,7 +765,7 @@ export default function AccountSetupFlow({ initialStep = 0, userName, onComplete
             key="connecting"
             onSuccess={handlePlaidSuccess}
             onError={handlePlaidError}
-            onBack={() => goTo(1)}
+            onBack={() => isMockEnv ? goTo(1) : undefined}
           />
         );
       case 3:
@@ -735,6 +780,10 @@ export default function AccountSetupFlow({ initialStep = 0, userName, onComplete
         return null;
     }
   };
+
+  // In production: map step 2→dot 0, step 3→dot 1 (no dots for Google gate)
+  const showDots = isMockEnv ? true : step >= 2;
+  const dotCurrent = isMockEnv ? step : step - 2;
 
   return (
     <div className="flex w-full max-w-lg flex-col items-center px-5 sm:px-6">
@@ -756,10 +805,12 @@ export default function AccountSetupFlow({ initialStep = 0, userName, onComplete
         </AnimatePresence>
       </div>
 
-      {/* Pagination dots */}
-      <div className="mt-12">
-        <PaginationDots current={step} total={TOTAL_STEPS} />
-      </div>
+      {/* Pagination dots — hidden for Google gate in production */}
+      {showDots && (
+        <div className="mt-12">
+          <PaginationDots current={dotCurrent} total={TOTAL_STEPS} />
+        </div>
+      )}
 
       {/* "Already have an account?" — fixed bottom-right, visible on pre-auth steps */}
       <AnimatePresence>

--- a/src/components/providers/UserProvider.jsx
+++ b/src/components/providers/UserProvider.jsx
@@ -315,6 +315,30 @@ export default function UserProvider({ children }) {
         // Only reset refs on actual sign-in, not on INITIAL_SESSION/TOKEN_REFRESHED
         fetchedRef.current = true; // mark as fetched so init IIFE doesn't double-fetch
         profileLoadingRef.current = true;
+
+        // For Google OAuth sign-ins, seed profile from user_metadata if no profile exists yet
+        const isGoogleProvider = nextUser.app_metadata?.provider === "google" ||
+          nextUser.identities?.some((id) => id.provider === "google");
+        if (isGoogleProvider) {
+          try {
+            const { fetchUserProfile: fetchP, upsertUserProfile: upsertP } = await import("../../lib/user/profile");
+            const { profile: existingProfile } = await fetchP();
+            if (!existingProfile || !existingProfile.first_name) {
+              const meta = nextUser.user_metadata || {};
+              const firstName = meta.given_name || meta.full_name?.split(" ")[0] || null;
+              const lastName = meta.family_name || (meta.full_name?.split(" ").slice(1).join(" ") || null);
+              const avatarUrl = meta.avatar_url || meta.picture || null;
+              await upsertP({
+                first_name: firstName || null,
+                last_name: lastName || null,
+                avatar_url: avatarUrl || null,
+              });
+            }
+          } catch (e) {
+            console.error("[UserProvider] Google profile seed error", e);
+          }
+        }
+
         if (await redirectFromPublicRoute()) {
           // Profile will be loaded by the [user,profile] effect after redirect
           profileLoadingRef.current = false;

--- a/src/lib/supabase/client.js
+++ b/src/lib/supabase/client.js
@@ -15,6 +15,7 @@ const createServerSafeStub = () => ({
     refreshSession: async () => ({ data: { session: null }, error: null }),
     signOut: async () => ({ error: null }),
     signInWithPassword: async () => ({ data: null, error: new Error("Supabase client unavailable during server build") }),
+    signInWithOAuth: async () => ({ data: null, error: new Error("Supabase client unavailable during server build") }),
     signUp: async () => ({ data: null, error: new Error("Supabase client unavailable during server build") }),
     updateUser: async () => ({ data: null, error: new Error("Supabase client unavailable during server build") }),
     resetPasswordForEmail: async () => ({ data: null, error: new Error("Supabase client unavailable during server build") }),


### PR DESCRIPTION
## Summary

Implements issue #54: In production, replace email/password auth with Google OAuth only.

**Flag:** `NEXT_PUBLIC_PLAID_ENV === 'mock'` → email/password flow. Otherwise → Google OAuth.

## Changes

### Auth page
- In production: replaces the email/password form with a single "Sign in with Google" button
- Google G logo inline SVG, white bg, thin zinc border
- Hides "Don't have an account?" and "Forgot password?" links in production

### FTUX AccountSetupFlow
- In production: steps 0 (name) and 1 (email/password) replaced with `GoogleSignUpGate`
- Pagination dots: 4 in mock/dev, 2 in production

### Profile creation (UserProvider)
- On `SIGNED_IN` with Google provider, seeds `user_profiles` row from `user_metadata` if no profile exists yet

## Validation
- `npx tsc --noEmit`: zero errors
- Mock/test email/password flow: untouched