### PR TITLE
fix: resolve sign-out spinner and account deletion auth bugs (#63)

### DIFF
--- a/src/app/(main)/settings/page.jsx
+++ b/src/app/(main)/settings/page.jsx
@@ -510,7 +510,11 @@ export default function SettingsPage() {
               <div className="text-xs text-[var(--color-muted)] mt-0.5">Sign out of your account on this device.</div>
             </div>
             <Button
-              onClick={logout}
+              onClick={async () => {
+                await supabase.auth.signOut();
+                logout();
+                router.replace("/");
+              }}
               variant="primary"
               size="sm"
             >

--- a/src/components/layout/SidebarContent.tsx
+++ b/src/components/layout/SidebarContent.tsx
@@ -342,8 +342,8 @@ export default function SidebarContent({ onNavigate, isCollapsed }: { onNavigate
           onConfirm={async () => {
             try {
               setIsSigningOut(true);
-              logout();
               await supabase.auth.signOut();
+              logout();
               onNavigate?.();
               router.replace("/");
             } finally {

--- a/src/components/providers/UserProvider.jsx
+++ b/src/components/providers/UserProvider.jsx
@@ -334,7 +334,9 @@ export default function UserProvider({ children }) {
         return;
       }
       if (event === "SIGNED_OUT") {
+        clearStaleAuthData();
         setProfile(null);
+        setUser(null);
         // Apply default theme when logged out
         document.documentElement.classList.toggle("dark", false);
         applyAccent(null);

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -55,13 +55,21 @@ export async function authFetch(
 
   let response = await fetch(input, { ...init, headers });
 
-  // If auth wasn't ready yet and middleware returned 401, try one token refresh + retry.
+  // If auth wasn't ready yet and middleware returned 401, force a real token refresh + retry.
   if (!hadAuthHeader && response.status === 401) {
-    const retryToken = await getAccessToken();
-    if (retryToken) {
-      const retryHeaders = new Headers(init?.headers);
-      retryHeaders.set("Authorization", `Bearer ${retryToken}`);
-      response = await fetch(input, { ...init, headers: retryHeaders });
+    try {
+      const refreshResult = await Promise.race([
+        supabase.auth.refreshSession(),
+        new Promise<{ data: null }>((resolve) => setTimeout(() => resolve({ data: null }), 3000)),
+      ]);
+      const retryToken = refreshResult?.data?.session?.access_token ?? null;
+      if (retryToken) {
+        const retryHeaders = new Headers(init?.headers);
+        retryHeaders.set("Authorization", `Bearer ${retryToken}`);
+        response = await fetch(input, { ...init, headers: retryHeaders });
+      }
+    } catch {
+      // Refresh failed, return original 401 response
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes two auth bugs reported in issue #63.

## Bug 1: Sign-out causes infinite loading spinner

**Root cause:** `logout()` was called before `supabase.auth.signOut()`. The `logout()` function immediately clears user/profile state → triggers loading spinner overlay → `onAuthStateChange` fires `SIGNED_OUT` but loading was already stuck.

**Fixes:**
- `SidebarContent.tsx`: reordered to `await supabase.auth.signOut()` → `logout()` → redirect
- `settings/page.jsx` sign-out button: replaced plain `logout()` call with proper async handler: await signOut → logout → replace('/')
- `UserProvider.jsx` SIGNED_OUT handler: added `clearStaleAuthData()` and explicit `setUser(null)` to fully purge state and localStorage `sb-*` keys

## Bug 2: Account deletion returns 401 Unauthorized

**Root cause:** `authFetch` retry on 401 was re-using the same potentially stale/cached token instead of forcing a fresh refresh.

**Fix:** `src/lib/api/fetch.ts` — on 401 retry, call `supabase.auth.refreshSession()` (with 3s timeout) to get a fresh token before retrying the request.

## Testing
- TypeScript: `npx tsc --noEmit` — zero errors