### PR TITLE
feat: filter investment accounts on free tier + Plaid update mode for upgrades (#67)

### DIFF
--- a/scripts/cleanup-free-tier-investment-accounts.js
+++ b/scripts/cleanup-free-tier-investment-accounts.js
@@ -1,0 +1,115 @@
+/**
+ * cleanup-free-tier-investment-accounts.js
+ *
+ * One-time cleanup script to remove investment accounts that were saved for
+ * free-tier users before tier-based filtering was introduced (issue #67).
+ *
+ * Usage:
+ *   DRY_RUN=1 node scripts/cleanup-free-tier-investment-accounts.js   # preview
+ *   node scripts/cleanup-free-tier-investment-accounts.js              # actually delete
+ *
+ * Requires environment variables: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('❌ Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+async function run() {
+  console.log(`🔍 Mode: ${DRY_RUN ? 'DRY RUN (no deletions)' : 'LIVE (will delete)'}`);
+
+  // Find all free-tier users
+  const { data: freeUsers, error: usersError } = await supabase
+    .from('user_profiles')
+    .select('id, subscription_tier')
+    .or('subscription_tier.eq.free,subscription_tier.is.null');
+
+  if (usersError) {
+    console.error('❌ Error fetching free-tier users:', usersError.message);
+    process.exit(1);
+  }
+
+  console.log(`👤 Found ${freeUsers.length} free-tier user(s)`);
+
+  let totalGhost = 0;
+  let totalDeleted = 0;
+
+  for (const user of freeUsers) {
+    // Find investment accounts for this user
+    const { data: investAccounts, error: accError } = await supabase
+      .from('accounts')
+      .select('id, name, subtype, plaid_item_id')
+      .eq('user_id', user.id)
+      .eq('type', 'investment');
+
+    if (accError) {
+      console.warn(`⚠️ Error fetching accounts for user ${user.id}:`, accError.message);
+      continue;
+    }
+
+    if (!investAccounts || investAccounts.length === 0) continue;
+
+    totalGhost += investAccounts.length;
+    console.log(`\n🏦 User ${user.id} (${user.subscription_tier || 'free'}): ${investAccounts.length} ghost investment account(s)`);
+    investAccounts.forEach(a => console.log(`   - [${a.id}] ${a.name} (${a.subtype})`));
+
+    if (!DRY_RUN) {
+      const ids = investAccounts.map(a => a.id);
+
+      // Delete associated holdings and investment transactions first (FK constraint)
+      const { error: holdingsErr } = await supabase
+        .from('holdings')
+        .delete()
+        .in('account_id', ids);
+      if (holdingsErr) console.warn(`   ⚠️ Error deleting holdings:`, holdingsErr.message);
+
+      const { error: invTxErr } = await supabase
+        .from('investment_transactions')
+        .delete()
+        .in('account_id', ids);
+      if (invTxErr) console.warn(`   ⚠️ Error deleting investment transactions:`, invTxErr.message);
+
+      const { error: snapErr } = await supabase
+        .from('account_snapshots')
+        .delete()
+        .in('account_id', ids);
+      if (snapErr) console.warn(`   ⚠️ Error deleting account snapshots:`, snapErr.message);
+
+      // Delete the accounts
+      const { error: deleteErr } = await supabase
+        .from('accounts')
+        .delete()
+        .in('id', ids);
+
+      if (deleteErr) {
+        console.error(`   ❌ Error deleting accounts:`, deleteErr.message);
+      } else {
+        console.log(`   ✅ Deleted ${ids.length} investment account(s)`);
+        totalDeleted += ids.length;
+      }
+    }
+  }
+
+  console.log('\n📊 Summary:');
+  console.log(`   Ghost investment accounts found: ${totalGhost}`);
+  if (DRY_RUN) {
+    console.log(`   Would delete: ${totalGhost} (run without DRY_RUN=1 to apply)`);
+  } else {
+    console.log(`   Deleted: ${totalDeleted}`);
+  }
+}
+
+run().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/src/app/(main)/settings/page.jsx
+++ b/src/app/(main)/settings/page.jsx
@@ -31,6 +31,8 @@ export default function SettingsPage() {
   const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [isPlaidModalOpen, setIsPlaidModalOpen] = useState(false);
   const [isUpgradeModalOpen, setIsUpgradeModalOpen] = useState(false);
+  // plaidItemId to pass into PlaidLinkModal for update-mode investment linking
+  const [upgradePlaidItemId, setUpgradePlaidItemId] = useState(null);
   const [isResyncing, setIsResyncing] = useState(false);
   const [isPortalLoading, setIsPortalLoading] = useState(false);
 
@@ -237,6 +239,17 @@ export default function SettingsPage() {
       setIsUpgradeModalOpen(true);
       return;
     }
+    setUpgradePlaidItemId(null);
+    setIsPlaidModalOpen(true);
+  };
+
+  // Handler for adding investments to an existing connected institution (pro upgrade flow)
+  const handleAddInvestments = (institution) => {
+    if (!institution.plaidItemId) {
+      alert('Unable to add investments: Missing Plaid item information.');
+      return;
+    }
+    setUpgradePlaidItemId(institution.plaidItemId);
     setIsPlaidModalOpen(true);
   };
 
@@ -428,6 +441,20 @@ export default function SettingsPage() {
                           </div>
                         </div>
                         <div className="flex items-center">
+                          {/* Show "Add investments" button for pro users whose institution has no investment accounts */}
+                          {isPro && !institution.accounts.some(a => a.type === 'investment') && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleAddInvestments(institution);
+                              }}
+                              className="p-1.5 rounded text-[var(--color-muted)] opacity-0 group-hover:opacity-100 hover:text-[var(--color-accent)] hover:bg-[var(--color-accent)]/10 transition-all text-[11px] font-medium mr-0.5 flex items-center gap-1"
+                              title="Add investment accounts"
+                            >
+                              <FaPlus className="h-2.5 w-2.5" />
+                              <span className="hidden sm:inline">Investments</span>
+                            </button>
+                          )}
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
@@ -641,14 +668,19 @@ export default function SettingsPage() {
         busyLabel="Disconnecting..."
       />
 
-      {/* Plaid Link Modal */}
+      {/* Plaid Link Modal — also used for update-mode investment linking on existing institutions */}
       <PlaidLinkModal
         isOpen={isPlaidModalOpen}
-        onClose={() => setIsPlaidModalOpen(false)}
+        onClose={() => {
+          setIsPlaidModalOpen(false);
+          setUpgradePlaidItemId(null);
+        }}
         onUpgradeNeeded={() => {
           setIsPlaidModalOpen(false);
+          setUpgradePlaidItemId(null);
           setIsUpgradeModalOpen(true);
         }}
+        plaidItemId={upgradePlaidItemId}
       />
 
       {/* Upgrade Modal */}

--- a/src/app/api/plaid/exchange-token/route.js
+++ b/src/app/api/plaid/exchange-token/route.js
@@ -2,29 +2,50 @@ import { exchangePublicToken, getAccounts, getInstitution } from '../../../../li
 import { supabaseAdmin } from '../../../../lib/supabase/admin';
 import { createAccountSnapshots } from '../../../../lib/accountSnapshotUtils';
 import { requireVerifiedUserId } from '../../../../lib/api/auth';
+import { getPlaidProducts } from '../../../../lib/tierConfig';
 
 export async function POST(request) {
   try {
     const userId = requireVerifiedUserId(request);
-    const { publicToken } = await request.json();
+    const { publicToken, existingPlaidItemId } = await request.json();
     if (!publicToken) {
       return Response.json(
         { error: 'Public token is required' },
         { status: 400 }
       );
     }
+
+    // Fetch user's subscription tier for tier-based filtering
+    const { data: userProfile } = await supabaseAdmin
+      .from('user_profiles')
+      .select('subscription_tier')
+      .eq('id', userId)
+      .maybeSingle();
+    const subscriptionTier = userProfile?.subscription_tier || 'free';
+    const tierPlaidProducts = getPlaidProducts(subscriptionTier);
+    const tierAllowsInvestments = tierPlaidProducts.includes('investments');
+
     // Exchange public token for access token
     const tokenResponse = await exchangePublicToken(publicToken);
     const { access_token, item_id } = tokenResponse;
     // Get accounts from Plaid
     const accountsResponse = await getAccounts(access_token);
-    const { accounts, institution_id } = accountsResponse;
-    console.log(`📊 Found ${accounts.length} total accounts for institution: ${institution_id || accountsResponse.item?.institution_id}`);
+    const { accounts: allAccounts, institution_id } = accountsResponse;
+    console.log(`📊 Found ${allAccounts.length} total accounts for institution: ${institution_id || accountsResponse.item?.institution_id}`);
+
+    // Filter out investment accounts if tier doesn't include investments product
+    const accounts = tierAllowsInvestments
+      ? allAccounts
+      : allAccounts.filter(a => a.type !== 'investment');
+
+    if (!tierAllowsInvestments && allAccounts.some(a => a.type === 'investment')) {
+      console.log(`🔒 Filtered out ${allAccounts.filter(a => a.type === 'investment').length} investment account(s) — tier "${subscriptionTier}" does not include investments`);
+    }
 
     if (accounts.length === 0) {
-      console.warn('⚠️ No accounts returned from Plaid');
+      console.warn('⚠️ No accounts available after tier filtering');
       return Response.json(
-        { error: 'No accounts found', details: 'Plaid returned no accounts for this institution.' },
+        { error: 'No accounts found', details: 'No eligible accounts found for your plan. Investment accounts require a Pro subscription.' },
         { status: 400 }
       );
     }
@@ -136,22 +157,54 @@ export async function POST(request) {
       }
     }
 
+    // Determine if this is an update-mode flow merging into an existing plaid_item
+    let existingPlaidItem = null;
+    if (existingPlaidItemId) {
+      const { data: existingItem } = await supabaseAdmin
+        .from('plaid_items')
+        .select('*')
+        .eq('id', existingPlaidItemId)
+        .eq('user_id', userId)
+        .maybeSingle();
+      existingPlaidItem = existingItem || null;
+      if (existingPlaidItem) {
+        console.log(`🔄 Update mode: merging into existing plaid_item ${existingPlaidItemId} (item_id: ${existingPlaidItem.item_id})`);
+      }
+    }
+
     // First, create or update the plaid_item
-    const { data: plaidItemData, error: plaidItemError } = await supabaseAdmin
-      .from('plaid_items')
-      .upsert({
-        user_id: userId,
-        item_id: item_id,
-        access_token: access_token,
-        sync_status: 'idle',
-        products: products,
-        // recurring_ready: true for items that have transaction accounts
-        recurring_ready: hasTransactionAccounts,
-      }, {
-        onConflict: 'user_id,item_id'
-      })
-      .select()
-      .single();
+    // In update mode, we update the existing item's products and access_token rather than creating a new one
+    let plaidItemData, plaidItemError;
+    if (existingPlaidItem) {
+      // Update existing item — merge products and update access_token
+      const mergedProducts = Array.from(new Set([...(existingPlaidItem.products || []), ...products]));
+      ({ data: plaidItemData, error: plaidItemError } = await supabaseAdmin
+        .from('plaid_items')
+        .update({
+          access_token: access_token,
+          products: mergedProducts,
+          sync_status: 'idle',
+        })
+        .eq('id', existingPlaidItem.id)
+        .select()
+        .single());
+    } else {
+      ({ data: plaidItemData, error: plaidItemError } = await supabaseAdmin
+        .from('plaid_items')
+        .upsert({
+          user_id: userId,
+          item_id: item_id,
+          access_token: access_token,
+          sync_status: 'idle',
+          products: products,
+          // recurring_ready: true for items that have transaction accounts
+          recurring_ready: hasTransactionAccounts,
+        }, {
+          onConflict: 'user_id,item_id'
+        })
+        .select()
+        .single());
+    }
     if (plaidItemError) {
       console.error('Error upserting plaid item:', plaidItemError);
       return Response.json(
@@ -160,12 +213,15 @@ export async function POST(request) {
       );
     }
 
+    // In update mode, use the existing item's item_id so accounts are associated correctly
+    const effectiveItemId = existingPlaidItem ? existingPlaidItem.item_id : item_id;
+
     // Process and save all accounts
     const accountsToInsert = [];
     const accountsToUpdate = [];
 
     for (const account of accounts) {
-      const accountKey = `${item_id}_${account.account_id}`;
+      const accountKey = `${effectiveItemId}_${account.account_id}`;
       const isInvestmentAccount = account.type === 'investment';
 
       if (isInvestmentAccount) {
@@ -173,7 +229,7 @@ export async function POST(request) {
         let { data: existingAccount } = await supabaseAdmin
           .from('accounts')
           .select('*')
-          .eq('item_id', item_id)
+          .eq('item_id', effectiveItemId)
           .eq('account_id', account.account_id)
           .eq('user_id', userId)
           .maybeSingle();
@@ -183,7 +239,7 @@ export async function POST(request) {
           const { data: matchedAccount } = await supabaseAdmin
             .from('accounts')
             .select('*')
-            .eq('item_id', item_id)
+            .eq('item_id', effectiveItemId)
             .eq('name', account.name)
             .eq('type', 'investment')
             .eq('user_id', userId)
@@ -208,7 +264,7 @@ export async function POST(request) {
         } else {
           accountsToInsert.push({
             user_id: userId,
-            item_id: item_id,
+            item_id: effectiveItemId,
             account_id: account.account_id,
             name: account.name,
             mask: account.mask,
@@ -226,7 +282,7 @@ export async function POST(request) {
         // Depository / credit account
         accountsToInsert.push({
           user_id: userId,
-          item_id: item_id,
+          item_id: effectiveItemId,
           account_id: account.account_id,
           name: account.name,
           mask: account.mask,

--- a/src/app/api/plaid/link-token/route.js
+++ b/src/app/api/plaid/link-token/route.js
@@ -39,13 +39,14 @@ export async function POST(request) {
         );
       }
       const accessToken = plaidItem.access_token;
-      // For update mode, request transactions product consent
-      const products = additionalProducts || ['transactions'];
+      // For update mode, request the additional products (default to investments for upgrade flow)
+      const products = additionalProducts || ['investments'];
       const linkTokenResponse = await createLinkToken(userId, products, null, accessToken);
       return Response.json({
         link_token: linkTokenResponse.link_token,
         expiration: linkTokenResponse.expiration,
         updateMode: true,
+        plaidItemId,
       });
     }
 

--- a/src/app/api/plaid/webhook/route.js
+++ b/src/app/api/plaid/webhook/route.js
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { createPublicKey } from 'crypto';
 import { createLogger } from '../../../../lib/logger';
+import { getPlaidProducts } from '../../../../lib/tierConfig';
 
 const DISABLE_WEBHOOKS = process.env.NODE_ENV !== 'production' && process.env.DISABLE_WEBHOOKS === '1';
 
@@ -297,12 +298,35 @@ async function handleItemWebhook(webhookData, logger) {
       // New accounts are available, sync them
       itemLogger.info('New accounts available', { item_id });
       try {
+        // Look up user's tier to filter accounts appropriately
+        const { data: userProfile } = await supabaseAdmin
+          .from('user_profiles')
+          .select('subscription_tier')
+          .eq('id', plaidItem.user_id)
+          .maybeSingle();
+        const subscriptionTier = userProfile?.subscription_tier || 'free';
+        const tierPlaidProducts = getPlaidProducts(subscriptionTier);
+        const tierAllowsInvestments = tierPlaidProducts.includes('investments');
+
         // Get fresh account data from Plaid
         const { getAccounts, getInstitution } = await import('../../../../lib/plaid/client');
         const accountsResponse = await getAccounts(plaidItem.access_token);
-        const { accounts, institution_id } = accountsResponse;
+        const { accounts: allAccounts, institution_id } = accountsResponse;
 
-        itemLogger.info('Fetched accounts from Plaid', { item_id, count: accounts.length });
+        // Filter out investment accounts if tier doesn't allow it
+        const accounts = tierAllowsInvestments
+          ? allAccounts
+          : allAccounts.filter(a => a.type !== 'investment');
+
+        if (!tierAllowsInvestments && allAccounts.some(a => a.type === 'investment')) {
+          itemLogger.info('Filtered investment accounts due to tier restrictions', {
+            item_id,
+            filtered_count: allAccounts.filter(a => a.type === 'investment').length,
+            tier: subscriptionTier,
+          });
+        }
+
+        itemLogger.info('Fetched accounts from Plaid', { item_id, total: allAccounts.length, eligible: accounts.length });
 
         // Get institution info (with fallback)
         let institutionData = null;

--- a/src/components/PlaidLinkModal.jsx
+++ b/src/components/PlaidLinkModal.jsx
@@ -12,7 +12,7 @@ import { authFetch } from '../lib/api/fetch';
 
 const isMockPlaid = process.env.NEXT_PUBLIC_PLAID_ENV === 'mock';
 
-export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCallback = null, onUpgradeNeeded = null }) {
+export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCallback = null, onUpgradeNeeded = null, plaidItemId = null }) {
   const { user } = useUser();
   const { addAccount, refreshAccounts } = useAccounts();
   const [linkToken, setLinkToken] = useState(null);
@@ -20,6 +20,8 @@ export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCa
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
   const [showMockPicker, setShowMockPicker] = useState(false);
+  // Track the plaidItemId returned from link-token in update mode
+  const [activePlaidItemId, setActivePlaidItemId] = useState(plaidItemId);
 
   useEffect(() => {
     if (!isOpen) {
@@ -27,8 +29,9 @@ export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCa
       setError(null);
       setSuccess(false);
       setLoading(false);
+      setActivePlaidItemId(plaidItemId);
     }
-  }, [isOpen]);
+  }, [isOpen, plaidItemId]);
 
   const exchangeToken = async (publicToken) => {
     try {
@@ -36,10 +39,16 @@ export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCa
       setError(null);
       setShowMockPicker(false);
 
+      const body = { publicToken };
+      // In update mode, pass the existing plaidItemId so the backend merges rather than creates
+      if (activePlaidItemId) {
+        body.existingPlaidItemId = activePlaidItemId;
+      }
+
       const response = await authFetch('/api/plaid/exchange-token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ publicToken }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {
@@ -107,10 +116,17 @@ export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCa
       setLoading(true);
       setError(null);
 
+      const linkTokenBody = {};
+      // If a plaidItemId was passed as prop, request update mode (for pro upgrades adding investments)
+      if (activePlaidItemId) {
+        linkTokenBody.plaidItemId = activePlaidItemId;
+        linkTokenBody.additionalProducts = ['investments'];
+      }
+
       const response = await authFetch('/api/plaid/link-token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify(linkTokenBody),
       });
 
       if (!response.ok) {
@@ -125,6 +141,11 @@ export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCa
       }
 
       const data = await response.json();
+
+      // Capture plaidItemId from update mode response so exchange-token can merge correctly
+      if (data.plaidItemId) {
+        setActivePlaidItemId(data.plaidItemId);
+      }
 
       if (isMockPlaid) {
         setLoading(false);
@@ -153,6 +174,7 @@ export default function PlaidLinkModal({ isOpen, onClose, onSuccess: onSuccessCa
     setLinkToken(null);
     setLoading(false);
     setShowMockPicker(false);
+    setActivePlaidItemId(plaidItemId);
   };
 
   const handleRetry = async () => {


### PR DESCRIPTION
Closes #67

## Changes

### Part 1: Tier-based filtering in `exchange-token`
- Fetches user's `subscription_tier` at ingest time
- Uses `getPlaidProducts(tier)` from `tierConfig.ts` to check if `investments` is allowed
- Filters out accounts where `type === 'investment'` for free-tier users before any DB writes
- Returns a clear error if all accounts were filtered (e.g. investment-only institution on free tier)

### Part 2: Plaid update mode for pro upgrades
- `link-token`: defaults `additionalProducts` to `['investments']` for update-mode flows, returns `plaidItemId` in the response
- `exchange-token`: accepts `existingPlaidItemId` — when present, updates the existing `plaid_items` row (merges products, updates access_token) instead of creating a duplicate, and uses the existing `item_id` for account matching
- `PlaidLinkModal`: accepts a `plaidItemId` prop; passes it to `link-token` to trigger update mode and captures the returned `plaidItemId` for the `exchange-token` merge
- `settings/page.jsx`: adds an "Add investments" button (hover-reveal) on institution rows for pro users without investment accounts; wires up the update-mode Plaid flow

### Part 3: Webhook fix
- `NEW_ACCOUNTS_AVAILABLE` handler now looks up user tier and filters investment accounts for free-tier users before upserting

### Part 4: Cleanup script
- `scripts/cleanup-free-tier-investment-accounts.js`: one-time script to remove ghost investment accounts saved before this fix. Supports `DRY_RUN=1` mode for preview.
