### PR TITLE
Monorepo step 4: scaffold apps/admin (admin.zervo.app)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,12 +33,21 @@ jobs:
         env:
           CI: true
 
-      - name: Build application
+      - name: Build finance
         run: pnpm --filter @zervo/finance build
         env:
           SKIP_ENV_VALIDATION: true
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Build admin
+        run: pnpm --filter @zervo/admin build
+        env:
+          SKIP_ENV_VALIDATION: true
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          ADMIN_EMAILS: asnair159@gmail.com
           
   deploy-production:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,8 @@ Example: `apps/finance/src/app/api/budgets/route.js`
 
 ## Deployment
 
-- **apps/finance**: Vercel project — Root Directory set to `apps/finance`. Auto-deploy on push to `main`.
-- **apps/admin** (planned): separate Vercel project at `admin.zervo.app` — Root Directory `apps/admin`. Same Supabase backend, gated by `ADMIN_EMAILS` allowlist.
+- **apps/finance**: Vercel project `zentari-next` — Root Directory `apps/finance`. Auto-deploy on push to `main`. Domain: `zervo.app`.
+- **apps/admin**: Vercel project `zervo-admin` — Root Directory `apps/admin`. Auto-deploy on push to `main`. Domain: `admin.zervo.app`. Same Supabase backend as finance, gated by `ADMIN_EMAILS` allowlist at middleware. Google OAuth via `supabase.auth.signInWithOAuth` (same Supabase Google provider as finance). Page port in dev: `3001` (`pnpm dev:admin`).
 
 ## Database Migrations
 

--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -1,0 +1,9 @@
+# Same Supabase project as apps/finance
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Comma-separated allowlist of email addresses permitted to access the admin
+# dashboard. Anyone signing in with Google whose email is not in this list
+# will be denied at the middleware layer.
+ADMIN_EMAILS=asnair159@gmail.com

--- a/apps/admin/eslint.config.mjs
+++ b/apps/admin/eslint.config.mjs
@@ -1,0 +1,5 @@
+import nextConfig from "eslint-config-next";
+
+const eslintConfig = [...nextConfig];
+
+export default eslintConfig;

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -1,0 +1,20 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: false,
+  transpilePackages: ['@zervo/ui'],
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'X-Robots-Tag', value: 'noindex, nofollow' },
+        ],
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zervo/admin",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start --port 3001",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@supabase/ssr": "^0.5.2",
+    "@supabase/supabase-js": "^2.57.2",
+    "@zervo/ui": "workspace:*",
+    "clsx": "^2.1.1",
+    "next": "^16.0.7",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
+    "react-icons": "^5.5.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/node": "^22",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.3",
+    "eslint": "^9.39.4",
+    "eslint-config-next": "^16.2.2",
+    "tailwindcss": "^4",
+    "typescript": "5.9.2"
+  }
+}

--- a/apps/admin/postcss.config.mjs
+++ b/apps/admin/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+
+export default config;

--- a/apps/admin/src/app/auth/callback/route.ts
+++ b/apps/admin/src/app/auth/callback/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * OAuth callback: Supabase redirects here with ?code=... after Google consent.
+ * We exchange the code for a session (which writes the auth cookie) and then
+ * bounce to the home page — middleware does the allowlist check from there.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/auth?error=exchange_failed`);
+}

--- a/apps/admin/src/app/auth/page.tsx
+++ b/apps/admin/src/app/auth/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@zervo/ui";
+import { createClient } from "@/lib/supabase/client";
+import { FcGoogle } from "react-icons/fc";
+
+export default function AuthPage() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSignIn() {
+    setLoading(true);
+    setError(null);
+    const supabase = createClient();
+    const { error: err } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    if (err) {
+      setError(err.message);
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-10">
+          <h1 className="text-2xl font-semibold text-[var(--color-fg)] mb-2">
+            Zervo Admin
+          </h1>
+          <p className="text-sm text-[var(--color-muted)]">
+            Restricted access. Sign in with Google.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          fullWidth
+          loading={loading}
+          onClick={handleSignIn}
+          className="h-11"
+        >
+          <FcGoogle className="mr-2 h-5 w-5" />
+          Continue with Google
+        </Button>
+        {error && (
+          <p className="mt-4 text-sm text-[var(--color-danger)]">{error}</p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/src/app/globals.css
+++ b/apps/admin/src/app/globals.css
@@ -1,0 +1,7 @@
+@import "tailwindcss";
+@source "../../../../packages/ui/src";
+@import "../styles/colors.css";
+
+html.dark {
+  color-scheme: dark;
+}

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Zervo Admin",
+  description: "Internal admin dashboard",
+  robots: { index: false, follow: false },
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen antialiased">{children}</body>
+    </html>
+  );
+}

--- a/apps/admin/src/app/not-authorized/page.tsx
+++ b/apps/admin/src/app/not-authorized/page.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import { Button } from "@zervo/ui";
+import { SignOutButton } from "@/components/SignOutButton";
+
+export default function NotAuthorizedPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6">
+      <div className="w-full max-w-md text-center">
+        <h1 className="text-2xl font-semibold text-[var(--color-fg)] mb-3">
+          Not authorized
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mb-8">
+          Your account is not on the admin allowlist. If you think this is a
+          mistake, contact Adarsh.
+        </p>
+        <div className="flex items-center justify-center gap-3">
+          <SignOutButton />
+          <Link href="https://zervo.app">
+            <Button variant="ghost">Go to Zervo</Button>
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { createClient, createAdminClient } from "@/lib/supabase/server";
+import { AdminShell } from "@/components/AdminShell";
+
+export default async function HomePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const admin = createAdminClient();
+
+  const [{ count: userCount }, { count: proCount }] = await Promise.all([
+    admin.from("profiles").select("*", { count: "exact", head: true }),
+    admin
+      .from("profiles")
+      .select("*", { count: "exact", head: true })
+      .eq("subscription_tier", "pro"),
+  ]);
+
+  return (
+    <AdminShell email={user?.email} activePath="/">
+      <header className="mb-8">
+        <h1 className="text-2xl font-semibold text-[var(--color-fg)]">
+          Overview
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          Signed in as {user?.email}
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10">
+        <StatCard label="Users" value={userCount ?? 0} />
+        <StatCard label="Pro subscribers" value={proCount ?? 0} />
+        <StatCard label="Households" value="—" muted />
+      </div>
+
+      <section className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+        <h2 className="text-sm font-semibold text-[var(--color-fg)] mb-2">
+          Quick actions
+        </h2>
+        <p className="text-sm text-[var(--color-muted)] mb-4">
+          Directly inspect a user's accounts, subscription, and transaction
+          counts.
+        </p>
+        <Link
+          href="/users"
+          className="inline-flex items-center gap-1 text-sm font-medium text-[var(--color-accent)] hover:underline"
+        >
+          Browse users →
+        </Link>
+      </section>
+    </AdminShell>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  muted = false,
+}: {
+  label: string;
+  value: number | string;
+  muted?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5">
+      <div className="text-xs uppercase tracking-wider text-[var(--color-muted)]">
+        {label}
+      </div>
+      <div
+        className={`mt-2 text-2xl font-semibold tabular-nums ${
+          muted ? "text-[var(--color-muted)]" : "text-[var(--color-fg)]"
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/users/page.tsx
+++ b/apps/admin/src/app/users/page.tsx
@@ -1,0 +1,134 @@
+import { createClient, createAdminClient } from "@/lib/supabase/server";
+import { AdminShell } from "@/components/AdminShell";
+
+export const dynamic = "force-dynamic";
+
+type User = {
+  id: string;
+  email: string | null;
+  created_at: string | null;
+  last_sign_in_at: string | null;
+};
+
+type Profile = {
+  id: string;
+  full_name: string | null;
+  subscription_tier: string | null;
+  subscription_status: string | null;
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default async function UsersPage() {
+  const supabase = await createClient();
+  const {
+    data: { user: me },
+  } = await supabase.auth.getUser();
+
+  const admin = createAdminClient();
+
+  const { data: authData, error: authErr } = await admin.auth.admin.listUsers({
+    page: 1,
+    perPage: 200,
+  });
+
+  const { data: profiles } = await admin
+    .from("profiles")
+    .select("id, full_name, subscription_tier, subscription_status");
+
+  const profileMap = new Map<string, Profile>();
+  (profiles ?? []).forEach((p) => profileMap.set(p.id, p as Profile));
+
+  const users: User[] = (authData?.users ?? []).map((u) => ({
+    id: u.id,
+    email: u.email ?? null,
+    created_at: u.created_at ?? null,
+    last_sign_in_at: u.last_sign_in_at ?? null,
+  }));
+
+  return (
+    <AdminShell email={me?.email} activePath="/users">
+      <header className="mb-8">
+        <h1 className="text-2xl font-semibold text-[var(--color-fg)]">
+          Users
+        </h1>
+        <p className="text-sm text-[var(--color-muted)] mt-1">
+          {users.length} total
+        </p>
+      </header>
+
+      {authErr ? (
+        <div className="rounded-md border border-[var(--color-danger)]/30 bg-[var(--color-danger)]/5 px-4 py-3 text-sm text-[var(--color-danger)]">
+          Failed to load users: {authErr.message}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--color-border)] text-xs uppercase tracking-wider text-[var(--color-muted)]">
+                <th className="px-5 py-3 text-left font-medium">Email</th>
+                <th className="px-5 py-3 text-left font-medium">Name</th>
+                <th className="px-5 py-3 text-left font-medium">Tier</th>
+                <th className="px-5 py-3 text-left font-medium">Joined</th>
+                <th className="px-5 py-3 text-left font-medium">Last login</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((u) => {
+                const p = profileMap.get(u.id);
+                const tier = p?.subscription_tier ?? "free";
+                return (
+                  <tr
+                    key={u.id}
+                    className="border-b border-[var(--color-border)] last:border-b-0 hover:bg-[var(--color-surface-alt)]/60 transition-colors"
+                  >
+                    <td className="px-5 py-3 text-[var(--color-fg)]">
+                      {u.email ?? "—"}
+                    </td>
+                    <td className="px-5 py-3 text-[var(--color-muted)]">
+                      {p?.full_name ?? "—"}
+                    </td>
+                    <td className="px-5 py-3">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium ${
+                          tier === "pro"
+                            ? "bg-[var(--color-accent)]/10 text-[var(--color-accent)]"
+                            : "bg-[var(--color-surface-alt)] text-[var(--color-muted)]"
+                        }`}
+                      >
+                        {tier}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3 text-[var(--color-muted)]">
+                      {formatDate(u.created_at)}
+                    </td>
+                    <td className="px-5 py-3 text-[var(--color-muted)]">
+                      {formatDate(u.last_sign_in_at)}
+                    </td>
+                  </tr>
+                );
+              })}
+              {users.length === 0 && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-5 py-8 text-center text-[var(--color-muted)]"
+                  >
+                    No users yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </AdminShell>
+  );
+}

--- a/apps/admin/src/components/AdminShell.tsx
+++ b/apps/admin/src/components/AdminShell.tsx
@@ -1,0 +1,98 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import { FiUsers, FiCreditCard, FiActivity, FiHome } from "react-icons/fi";
+import { SignOutButton } from "./SignOutButton";
+
+type NavItem = {
+  href: string;
+  label: string;
+  icon: ReactNode;
+  disabled?: boolean;
+};
+
+const NAV: NavItem[] = [
+  { href: "/", label: "Overview", icon: <FiHome className="h-4 w-4" /> },
+  { href: "/users", label: "Users", icon: <FiUsers className="h-4 w-4" /> },
+  {
+    href: "#",
+    label: "Subscriptions",
+    icon: <FiCreditCard className="h-4 w-4" />,
+    disabled: true,
+  },
+  {
+    href: "#",
+    label: "Audit log",
+    icon: <FiActivity className="h-4 w-4" />,
+    disabled: true,
+  },
+];
+
+type AdminShellProps = {
+  children: ReactNode;
+  email?: string | null;
+  activePath?: string;
+};
+
+export function AdminShell({ children, email, activePath = "/" }: AdminShellProps) {
+  return (
+    <div className="flex min-h-screen bg-[var(--color-content-bg)]">
+      <aside className="w-60 shrink-0 border-r border-[var(--color-border)] bg-[var(--color-sidebar-bg)] flex flex-col">
+        <div className="px-5 py-5 border-b border-[var(--color-border)]">
+          <div className="flex items-center gap-2">
+            <span className="h-2 w-2 rounded-full bg-[var(--color-accent)]" />
+            <span className="text-sm font-semibold text-[var(--color-fg)] tracking-wide">
+              ZERVO ADMIN
+            </span>
+          </div>
+        </div>
+        <nav className="flex-1 px-3 py-4 space-y-1">
+          {NAV.map((item) => {
+            const active = activePath === item.href;
+            const base =
+              "flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors";
+            if (item.disabled) {
+              return (
+                <span
+                  key={item.label}
+                  className={`${base} text-[var(--color-muted)]/60 cursor-not-allowed`}
+                  aria-disabled
+                >
+                  {item.icon}
+                  <span>{item.label}</span>
+                  <span className="ml-auto text-[10px] uppercase tracking-wider text-[var(--color-muted)]/50">
+                    soon
+                  </span>
+                </span>
+              );
+            }
+            return (
+              <Link
+                key={item.label}
+                href={item.href}
+                className={`${base} ${
+                  active
+                    ? "bg-[var(--color-sidebar-active)] text-[var(--color-fg)]"
+                    : "text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-sidebar-active)]/60"
+                }`}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+        <div className="px-4 py-4 border-t border-[var(--color-border)] flex flex-col gap-2">
+          {email && (
+            <div className="text-xs text-[var(--color-muted)] truncate" title={email}>
+              {email}
+            </div>
+          )}
+          <SignOutButton />
+        </div>
+      </aside>
+      <main className="flex-1 min-w-0 overflow-x-auto">
+        <div className="max-w-6xl mx-auto px-8 py-10">{children}</div>
+      </main>
+    </div>
+  );
+}

--- a/apps/admin/src/components/SignOutButton.tsx
+++ b/apps/admin/src/components/SignOutButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@zervo/ui";
+import { createClient } from "@/lib/supabase/client";
+
+export function SignOutButton() {
+  const [loading, setLoading] = useState(false);
+
+  async function handleSignOut() {
+    setLoading(true);
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    window.location.href = "/auth";
+  }
+
+  return (
+    <Button variant="outline" onClick={handleSignOut} loading={loading}>
+      Sign out
+    </Button>
+  );
+}

--- a/apps/admin/src/lib/auth/admin.ts
+++ b/apps/admin/src/lib/auth/admin.ts
@@ -1,0 +1,24 @@
+/**
+ * Admin allowlist check. The ADMIN_EMAILS env var holds a comma-separated
+ * list of email addresses permitted to access the admin dashboard.
+ *
+ * This is the sole gate. There is no "admin" flag in the database — we keep
+ * the allowlist in infrastructure config so it can't be escalated by anyone
+ * with DB write access.
+ */
+
+function getAllowlist(): Set<string> {
+  const raw = process.env.ADMIN_EMAILS ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+export function isAllowedAdmin(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const allowed = getAllowlist();
+  return allowed.has(email.toLowerCase());
+}

--- a/apps/admin/src/lib/supabase/client.ts
+++ b/apps/admin/src/lib/supabase/client.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}

--- a/apps/admin/src/lib/supabase/server.ts
+++ b/apps/admin/src/lib/supabase/server.ts
@@ -1,0 +1,46 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+
+type CookieToSet = { name: string; value: string; options?: CookieOptions };
+
+export async function createClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet: CookieToSet[]) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            // Called from a Server Component — safe to ignore; the middleware
+            // refreshes the session cookie on the next request.
+          }
+        },
+      },
+    },
+  );
+}
+
+// Service-role client for admin-only operations (reading the full user list,
+// deleting users, etc). NEVER expose this client to the browser.
+export function createAdminClient() {
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+}

--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -1,0 +1,76 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+import { isAllowedAdmin } from "./lib/auth/admin";
+
+type CookieToSet = { name: string; value: string; options?: CookieOptions };
+
+// Paths that do NOT require auth
+const PUBLIC_PATHS = ["/auth", "/auth/callback", "/not-authorized"];
+
+function isPublic(pathname: string): boolean {
+  return PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  let response = NextResponse.next({ request });
+
+  // Create Supabase client that refreshes the session cookie in-flight
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet: CookieToSet[]) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          response = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (isPublic(pathname)) {
+    // If already signed in as an allowed admin, bounce off /auth to home
+    if (pathname === "/auth" && user && isAllowedAdmin(user.email)) {
+      const url = request.nextUrl.clone();
+      url.pathname = "/";
+      return NextResponse.redirect(url);
+    }
+    return response;
+  }
+
+  // Protected route — must be signed in
+  if (!user) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/auth";
+    return NextResponse.redirect(url);
+  }
+
+  // And must be on the allowlist
+  if (!isAllowedAdmin(user.email)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/not-authorized";
+    return NextResponse.redirect(url);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    // Run on everything except static assets and Next internals
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/apps/admin/src/styles/colors.css
+++ b/apps/admin/src/styles/colors.css
@@ -1,0 +1,135 @@
+:root {
+  /* Clean Light Mode */
+  --color-bg: #ffffff;
+  --color-surface: #ffffff;
+  --color-fg: #18181b;
+  --color-muted: #52525b;
+  --color-border: #e4e4e7;
+  --color-ring: #a1a1aa;
+
+  --color-primary: #18181b;
+  --color-primary-hover: #27272a;
+  --color-on-primary: #ffffff;
+
+  /* Admin uses a distinct accent (slate blue) so it's visually identifiable */
+  --color-accent: #1e40af;
+  --color-accent-hover: #1e3a8a;
+  --color-on-accent: #ffffff;
+
+  --color-success: #059669;
+  --color-danger: #b91c1c;
+  --color-on-danger: #ffffff;
+
+  --color-input-bg: #f1f1f1;
+  --color-input-fg: #18181b;
+  --color-input-placeholder: #a1a1aa;
+
+  --color-surface-alt: #f1f1f1;
+  --color-dropdown-bg: var(--color-surface-alt);
+
+  --color-floating-bg: #18181b;
+  --color-floating-fg: #fafafa;
+  --color-floating-muted: #a1a1aa;
+  --color-floating-border: color-mix(in oklab, #ffffff, transparent 90%);
+
+  --color-content-bg: #fafafa;
+  --color-sidebar-bg: var(--color-content-bg);
+  --color-sidebar-active: var(--color-surface-alt);
+  --color-card-highlight: #f4f4f5;
+
+  --glass-bg: #ffffff;
+  --glass-border: #e4e4e7;
+  --glass-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+
+  --color-shadow: transparent;
+  --color-card-border: #e4e4e7;
+}
+
+.dark {
+  --color-bg: #0d0d0d;
+  --color-surface: #0d0d0d;
+  --color-fg: #e4e4e7;
+  --color-muted: #a1a1aa;
+  --color-border: #3f3f46;
+  --color-ring: #71717a;
+
+  --color-primary: #fafafa;
+  --color-primary-hover: #e4e4e7;
+  --color-on-primary: #09090b;
+
+  --color-accent: #3b82f6;
+  --color-accent-hover: #60a5fa;
+  --color-on-accent: #ffffff;
+
+  --color-success: #34d399;
+  --color-danger: #f87171;
+  --color-on-danger: #ffffff;
+
+  --color-input-bg: #181818;
+  --color-input-fg: #e4e4e7;
+  --color-input-placeholder: #71717a;
+
+  --color-surface-alt: #181818;
+  --color-dropdown-bg: var(--color-surface-alt);
+
+  --color-floating-bg: #fafafa;
+  --color-floating-fg: #18181b;
+  --color-floating-muted: #52525b;
+  --color-floating-border: color-mix(in oklab, #000000, transparent 88%);
+
+  --color-content-bg: #0d0d0d;
+  --color-sidebar-bg: var(--color-content-bg);
+  --color-sidebar-active: #1a1a1a;
+  --color-card-highlight: #181818;
+
+  --glass-bg: #111111;
+  --glass-border: #27272a;
+  --glass-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+
+  --color-shadow: transparent;
+  --color-card-border: #27272a;
+}
+
+html,
+body {
+  background-color: var(--color-content-bg);
+  color: var(--color-fg);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  min-width: 100%;
+}
+
+:where(button, [role="button"], a):focus-visible {
+  outline: 1px solid var(--color-ring);
+  outline-offset: 2px;
+  box-shadow: none;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+*:hover {
+  scrollbar-color: var(--color-border) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+*:hover::-webkit-scrollbar-thumb {
+  background-color: var(--color-border);
+}

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dev": "pnpm --filter @zervo/finance dev",
     "dev:finance": "pnpm --filter @zervo/finance dev",
+    "dev:admin": "pnpm --filter @zervo/admin dev",
     "build": "pnpm --filter @zervo/finance build",
     "build:finance": "pnpm --filter @zervo/finance build",
+    "build:admin": "pnpm --filter @zervo/admin build",
     "start": "pnpm --filter @zervo/finance start",
+    "start:admin": "pnpm --filter @zervo/admin start",
     "lint": "pnpm -r --parallel run lint",
     "test": "pnpm --filter @zervo/finance test",
     "test:watch": "pnpm --filter @zervo/finance test:watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,58 @@ importers:
 
   .: {}
 
+  apps/admin:
+    dependencies:
+      '@supabase/ssr':
+        specifier: ^0.5.2
+        version: 0.5.2(@supabase/supabase-js@2.104.0)
+      '@supabase/supabase-js':
+        specifier: ^2.57.2
+        version: 2.104.0
+      '@zervo/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      next:
+        specifier: ^16.0.7
+        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.5(react@19.2.5)
+      react-icons:
+        specifier: ^5.5.0
+        version: 5.6.0(react@19.2.5)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4
+        version: 4.2.4
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      eslint-config-next:
+        specifier: ^16.2.2
+        version: 16.2.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2)
+      tailwindcss:
+        specifier: ^4
+        version: 4.2.4
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
   apps/finance:
     dependencies:
       '@sentry/nextjs':
@@ -78,7 +130,7 @@ importers:
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@18.3.1)(react@19.2.5)(redux@5.0.1)
       stripe:
         specifier: ^21.0.1
-        version: 21.0.1(@types/node@25.6.0)
+        version: 21.0.1(@types/node@22.19.17)
       three:
         specifier: ^0.183.2
         version: 0.183.2
@@ -118,7 +170,7 @@ importers:
         version: 16.2.4(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2)
       jest:
         specifier: ^30.1.3
-        version: 30.3.0(@types/node@25.6.0)
+        version: 30.3.0(@types/node@22.19.17)
       jest-environment-jsdom:
         specifier: ^30.1.2
         version: 30.3.0
@@ -1325,6 +1377,11 @@ packages:
     resolution: {integrity: sha512-9fUVDoTVAhn7a79+AmEx+asUlRtf2yBrji7TQckcKn/WK4hvAA9Lia9er+lnhuz3WNiF1x6kkA4x7bRCJrU+KA==}
     engines: {node: '>=20.0.0'}
 
+  '@supabase/ssr@0.5.2':
+    resolution: {integrity: sha512-n3plRhr2Bs8Xun1o4S3k1CDv17iH5QY9YcoEvXX3bxV1/5XSasA0mNXYycFmADIdtdE6BG9MRjP5CGIs8qxC8A==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
+
   '@supabase/storage-js@2.104.0':
     resolution: {integrity: sha512-s2NHtuAWb9nldJ/fS62WnJE6edvCWn31rrO+FJKlAohs99qdVgtLegUReTU2H9WnZiQlVqaBtu386wt6/6lrRw==}
     engines: {node: '>=20.0.0'}
@@ -1468,6 +1525,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1537,8 +1597,8 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
   '@types/pg-pool@2.0.7':
     resolution: {integrity: sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==}
@@ -2098,6 +2158,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4213,8 +4277,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -4819,7 +4883,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -4833,14 +4897,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.6.0)
+      jest-config: 30.3.0(@types/node@22.19.17)
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -4868,7 +4932,7 @@ snapshots:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
       '@types/jsdom': 21.1.7
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jsdom: 26.1.0
@@ -4877,7 +4941,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -4895,7 +4959,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.3.2
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -4913,7 +4977,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.3.0':
@@ -4924,7 +4988,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -5000,7 +5064,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -5683,6 +5747,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@supabase/ssr@0.5.2(@supabase/supabase-js@2.104.0)':
+    dependencies:
+      '@supabase/supabase-js': 2.104.0
+      '@types/cookie': 0.6.0
+      cookie: 0.7.2
+
   '@supabase/storage-js@2.104.0':
     dependencies:
       iceberg-js: 0.8.1
@@ -5832,7 +5902,9 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
+
+  '@types/cookie@0.6.0': {}
 
   '@types/d3-array@3.2.2': {}
 
@@ -5889,7 +5961,7 @@ snapshots:
 
   '@types/jsdom@21.1.7':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
@@ -5900,17 +5972,17 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
 
   '@types/ms@2.1.0': {}
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
 
-  '@types/node@25.6.0':
+  '@types/node@22.19.17':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 6.21.0
 
   '@types/pg-pool@2.0.7':
     dependencies:
@@ -5918,7 +5990,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -5934,7 +6006,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -5942,7 +6014,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -6528,6 +6600,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@0.7.2: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -6807,8 +6881,28 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
+      globals: 16.4.0
+      typescript-eslint: 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
+  eslint-config-next@16.2.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.4
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -6830,6 +6924,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -6841,22 +6950,32 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6867,7 +6986,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -6880,6 +6999,33 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      hasown: 2.0.3
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.5
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7550,7 +7696,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -7570,7 +7716,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@25.6.0):
+  jest-cli@30.3.0(@types/node@22.19.17):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/test-result': 30.3.0
@@ -7578,7 +7724,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.6.0)
+      jest-config: 30.3.0(@types/node@22.19.17)
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -7589,7 +7735,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@25.6.0):
+  jest-config@30.3.0(@types/node@22.19.17):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -7615,7 +7761,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -7654,7 +7800,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -7662,7 +7808,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7701,7 +7847,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -7735,7 +7881,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -7764,7 +7910,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -7811,7 +7957,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -7830,7 +7976,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -7839,24 +7985,24 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@25.6.0):
+  jest@30.3.0(@types/node@22.19.17):
     dependencies:
       '@jest/core': 30.3.0
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.6.0)
+      jest-cli: 30.3.0(@types/node@22.19.17)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -8844,9 +8990,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  stripe@21.0.1(@types/node@25.6.0):
+  stripe@21.0.1(@types/node@22.19.17):
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
     dependencies:
@@ -9005,7 +9151,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.19.2: {}
+  undici-types@6.21.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:


### PR DESCRIPTION
## Summary
Barebones admin dashboard at `admin.zervo.app`. Shares the finance Supabase project and its existing Google OAuth provider — nothing new to click in Google Cloud or Supabase.

**v1 scope (per Adarsh):** Google login + landing page + user list.

**Auth model:** `ADMIN_EMAILS` env var (comma-separated allowlist) enforced by `middleware.ts`:
- not signed in → `/auth`
- signed in, email ∉ allowlist → `/not-authorized`
- signed in, email ∈ allowlist → continue

Allowlist is env-only, not a DB flag — so no one with DB write access can escalate.

**Vercel project:** `zervo-admin` (`prj_0iPC1CHOb7puvOWTunkvRIAo242R`), created via REST API with:
- Root Directory: `apps/admin`
- Env vars: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` (copied from finance), `ADMIN_EMAILS=asnair159@gmail.com`
- Domain: `admin.zervo.app` attached

**Still required (manual):**
- Add CNAME record on Namecheap:
  - Host: `admin`
  - Value: `cname.vercel-dns.com`
  - TTL: Automatic
- Propagation: ~10 min to 1 hr

## Test plan
- [ ] Vercel preview deploy on this PR goes green
- [ ] After merge, production deploy succeeds
- [ ] After Namecheap CNAME added, visit `https://admin.zervo.app` → redirect to `/auth`
- [ ] Sign in with Google (asnair159@gmail.com) → redirect to `/` with user count
- [ ] Sign in with a different Google account → redirect to `/not-authorized`
- [ ] `/users` shows the real Supabase user list

## Follow-ups
- Terraform for Vercel projects + DNS (separate PR)
- Migrate `zervo.app` DNS from Namecheap → Vercel DNS (separate PR)
- Scope items (c)–(f) from the plan: user detail, delete-user-with-Plaid-cleanup, subscription overrides, audit log