### PR TITLE
Terraform: Vercel projects + DNS under IaC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,13 @@ docs/pricing.md
 
 # Turbo cache (reserved for future use)
 .turbo/
+
+# Terraform
+infra/.terraform/
+infra/.terraform.lock.hcl
+infra/terraform.tfstate
+infra/terraform.tfstate.backup
+infra/crash.log
+infra/crash.*.log
+infra/*.tfvars
+!infra/*.tfvars.example

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,80 @@
+# infra/ — Terraform for Vercel + DNS
+
+Declarative state for everything on Vercel: both projects, their env vars and
+domains, and every DNS record on `zervo.app`.
+
+## Before you start
+
+Install Terraform (once, on the machine running `terraform apply`):
+
+```bash
+winget install Hashicorp.Terraform   # Windows
+brew install terraform                # macOS
+```
+
+Get a Vercel API token at https://vercel.com/account/tokens, then copy the
+template and fill in the secrets:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars (gitignored) and paste the real values
+```
+
+## Day-to-day
+
+```bash
+cd infra
+terraform plan    # see what will change
+terraform apply   # roll it out
+```
+
+Add a new subdomain? Add a resource block to `dns.tf`, `terraform apply`.
+Change an env var? Edit `vercel.tf`, `terraform apply`.
+
+## State
+
+State lives locally in `terraform.tfstate` (gitignored). If you lose it,
+you can re-import every resource — see the comments in `vercel.tf` and
+`dns.tf` for the import commands used originally.
+
+If the state starts to hurt (team access, fear of loss, etc.), migrate
+to Terraform Cloud with:
+
+```hcl
+# in main.tf
+backend "remote" {
+  organization = "zervo"
+  workspaces { name = "infra" }
+}
+```
+
+...then `terraform init -migrate-state` and commit.
+
+## One-time manual steps that don't live in code
+
+- **Google OAuth consent screen** — configured once in Google Cloud Console.
+- **Supabase Auth providers** — Google provider enabled in the Supabase
+  dashboard. Redirect URLs for admin should include
+  `https://admin.zervo.app/auth/callback`.
+- **Namecheap nameservers** — set to `ns1.vercel-dns.com` and
+  `ns2.vercel-dns.com`. The only reason to log back into Namecheap after
+  this is the annual domain renewal.
+
+## First-time bootstrap (already done, recorded for the archive)
+
+Both Vercel projects and the DNS zone already exist. To reproduce the state
+that Terraform now owns, these imports were run once:
+
+```bash
+terraform import vercel_project.finance prj_VoG2H8XSP6MAd8TvkcixeRifLTq4
+terraform import vercel_project.admin   prj_0iPC1CHOb7puvOWTunkvRIAo242R
+
+terraform import vercel_project_domain.finance_apex    zervo.app
+terraform import vercel_project_domain.finance_www     www.zervo.app
+terraform import vercel_project_domain.admin_subdomain admin.zervo.app
+
+# DNS records — IDs are in the Vercel dashboard / API response
+terraform import vercel_dns_record.apex_a  <rec_id>
+terraform import vercel_dns_record.www_cname <rec_id>
+# ...etc
+```

--- a/infra/dns.tf
+++ b/infra/dns.tf
@@ -1,0 +1,103 @@
+# -----------------------------------------------------------------------------
+# zervo.app — DNS records served by Vercel DNS
+# -----------------------------------------------------------------------------
+#
+# The domain is registered with Namecheap but its nameservers point at Vercel,
+# so every record below becomes a single source of truth. To add a new
+# subdomain, just add a resource block and `terraform apply`.
+#
+# Imports (one-time, when records were first mirrored in from Namecheap):
+#   terraform import vercel_dns_record.apex_a      rec_xxx
+#   terraform import vercel_dns_record.www_cname   rec_xxx
+#   ...and so on.
+# -----------------------------------------------------------------------------
+
+locals {
+  domain = "zervo.app"
+}
+
+# Apex A record → Vercel's Anycast IP. Anything else would break app routing.
+resource "vercel_dns_record" "apex_a" {
+  domain = local.domain
+  name   = ""
+  type   = "A"
+  value  = "216.198.79.1"
+  ttl    = 60
+}
+
+# www → redirects to apex (the redirect itself lives on the Vercel project).
+resource "vercel_dns_record" "www_cname" {
+  domain = local.domain
+  name   = "www"
+  type   = "CNAME"
+  value  = "cname.vercel-dns.com"
+  ttl    = 60
+}
+
+# Admin dashboard
+resource "vercel_dns_record" "admin_cname" {
+  domain = local.domain
+  name   = "admin"
+  type   = "CNAME"
+  value  = "cname.vercel-dns.com"
+  ttl    = 60
+}
+
+# -----------------------------------------------------------------------------
+# Email — Namecheap's free email forwarding (contact@zervo.app, etc)
+# Kept as-is so existing forwarding continues to work after the nameserver
+# switch. If email ever moves (e.g. to Google Workspace), update these.
+# -----------------------------------------------------------------------------
+
+resource "vercel_dns_record" "mx_1" {
+  domain    = local.domain
+  name      = ""
+  type      = "MX"
+  value     = "eforward1.registrar-servers.com"
+  mx_priority = 10
+  ttl       = 1800
+}
+
+resource "vercel_dns_record" "mx_2" {
+  domain    = local.domain
+  name      = ""
+  type      = "MX"
+  value     = "eforward2.registrar-servers.com"
+  mx_priority = 10
+  ttl       = 1800
+}
+
+resource "vercel_dns_record" "mx_3" {
+  domain    = local.domain
+  name      = ""
+  type      = "MX"
+  value     = "eforward3.registrar-servers.com"
+  mx_priority = 10
+  ttl       = 1800
+}
+
+resource "vercel_dns_record" "mx_4" {
+  domain      = local.domain
+  name        = ""
+  type        = "MX"
+  value       = "eforward4.registrar-servers.com"
+  mx_priority = 15
+  ttl         = 1800
+}
+
+resource "vercel_dns_record" "mx_5" {
+  domain      = local.domain
+  name        = ""
+  type        = "MX"
+  value       = "eforward5.registrar-servers.com"
+  mx_priority = 20
+  ttl         = 1800
+}
+
+resource "vercel_dns_record" "spf_txt" {
+  domain = local.domain
+  name   = ""
+  type   = "TXT"
+  value  = "v=spf1 include:spf.efwd.registrar-servers.com ~all"
+  ttl    = 1800
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 3.0"
+    }
+  }
+
+  # Local state. If state grows to matter, migrate to Terraform Cloud with:
+  #   backend "remote" { ... }
+  # and run `terraform init -migrate-state`.
+}
+
+provider "vercel" {
+  api_token = var.vercel_api_token
+  team      = var.vercel_team_id
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,12 @@
+output "finance_project_id" {
+  value = vercel_project.finance.id
+}
+
+output "admin_project_id" {
+  value = vercel_project.admin.id
+}
+
+output "vercel_nameservers" {
+  description = "Nameservers to set on Namecheap for zervo.app"
+  value       = ["ns1.vercel-dns.com", "ns2.vercel-dns.com"]
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Copy this file to terraform.tfvars (gitignored) and fill in the secrets.
+# Get the API token from https://vercel.com/account/tokens.
+# Get the Supabase values from `vercel env pull` in apps/finance, or from the
+# Supabase dashboard.
+
+vercel_api_token          = "vercel_..."
+supabase_url              = "https://xxxxx.supabase.co"
+supabase_anon_key         = "eyJhbGci..."
+supabase_service_role_key = "eyJhbGci..."

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,41 @@
+variable "vercel_api_token" {
+  description = "Vercel API token (https://vercel.com/account/tokens)"
+  type        = string
+  sensitive   = true
+}
+
+variable "vercel_team_id" {
+  description = "Vercel team ID (team_HlkHqpZOKsamypCa0L3G5Ird)"
+  type        = string
+  default     = "team_HlkHqpZOKsamypCa0L3G5Ird"
+}
+
+variable "github_repo" {
+  description = "GitHub repo in <owner>/<name> form"
+  type        = string
+  default     = "Adarsh-S-Nair/finance-next"
+}
+
+variable "admin_emails" {
+  description = "Comma-separated allowlist of emails permitted to access apps/admin"
+  type        = string
+  default     = "asnair159@gmail.com"
+}
+
+variable "supabase_url" {
+  description = "Supabase project URL — shared by apps/finance and apps/admin"
+  type        = string
+  sensitive   = true
+}
+
+variable "supabase_anon_key" {
+  description = "Supabase anon key — shared"
+  type        = string
+  sensitive   = true
+}
+
+variable "supabase_service_role_key" {
+  description = "Supabase service-role key — shared, server-side only"
+  type        = string
+  sensitive   = true
+}

--- a/infra/vercel.tf
+++ b/infra/vercel.tf
@@ -1,0 +1,101 @@
+# -----------------------------------------------------------------------------
+# Vercel projects
+# -----------------------------------------------------------------------------
+#
+# Both projects already exist in Vercel and are imported into this state — this
+# file is the source of truth going forward. Future changes (env vars, root
+# directory, etc) should be made here and rolled out via `terraform apply`.
+#
+# Import commands used to bring existing state in:
+#   terraform import vercel_project.finance prj_VoG2H8XSP6MAd8TvkcixeRifLTq4
+#   terraform import vercel_project.admin   prj_0iPC1CHOb7puvOWTunkvRIAo242R
+# -----------------------------------------------------------------------------
+
+resource "vercel_project" "finance" {
+  name      = "zentari-next"
+  framework = "nextjs"
+
+  root_directory = "apps/finance"
+  git_repository = {
+    type              = "github"
+    repo              = var.github_repo
+    production_branch = "main"
+  }
+
+  # Preview deploys require the Vercel login password (doesn't affect prod).
+  vercel_authentication = {
+    deployment_type = "standard_protection_new"
+  }
+}
+
+resource "vercel_project" "admin" {
+  name      = "zervo-admin"
+  framework = "nextjs"
+
+  root_directory = "apps/admin"
+  git_repository = {
+    type              = "github"
+    repo              = var.github_repo
+    production_branch = "main"
+  }
+
+  # Preview deploys require the Vercel login password (doesn't affect prod).
+  vercel_authentication = {
+    deployment_type = "standard_protection_new"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Admin env vars (finance env vars are managed in its own Vercel dashboard for
+# now — adding them here would risk clobbering prod secrets during import).
+# -----------------------------------------------------------------------------
+
+resource "vercel_project_environment_variable" "admin_supabase_url" {
+  project_id = vercel_project.admin.id
+  key        = "NEXT_PUBLIC_SUPABASE_URL"
+  value      = var.supabase_url
+  target     = ["production", "preview", "development"]
+}
+
+resource "vercel_project_environment_variable" "admin_supabase_anon_key" {
+  project_id = vercel_project.admin.id
+  key        = "NEXT_PUBLIC_SUPABASE_ANON_KEY"
+  value      = var.supabase_anon_key
+  target     = ["production", "preview", "development"]
+}
+
+resource "vercel_project_environment_variable" "admin_supabase_service_role_key" {
+  project_id = vercel_project.admin.id
+  key        = "SUPABASE_SERVICE_ROLE_KEY"
+  value      = var.supabase_service_role_key
+  sensitive  = true
+  # Vercel disallows `development` for sensitive env vars.
+  target     = ["production", "preview"]
+}
+
+resource "vercel_project_environment_variable" "admin_allowlist" {
+  project_id = vercel_project.admin.id
+  key        = "ADMIN_EMAILS"
+  value      = var.admin_emails
+  target     = ["production", "preview", "development"]
+}
+
+# -----------------------------------------------------------------------------
+# Domain attachments (project ↔ host)
+# -----------------------------------------------------------------------------
+
+resource "vercel_project_domain" "finance_apex" {
+  project_id = vercel_project.finance.id
+  domain     = "zervo.app"
+  redirect   = "www.zervo.app"
+}
+
+resource "vercel_project_domain" "finance_www" {
+  project_id = vercel_project.finance.id
+  domain     = "www.zervo.app"
+}
+
+resource "vercel_project_domain" "admin_subdomain" {
+  project_id = vercel_project.admin.id
+  domain     = "admin.zervo.app"
+}


### PR DESCRIPTION
## Summary
Declarative infrastructure for Vercel + DNS lives in `infra/`. Both Vercel projects and every record on `zervo.app` are now managed by Terraform. `vercel_dns` is authoritative on Vercel's side — one Namecheap nameserver change (below) and we never log into Namecheap for DNS again.

## What's in TF
- Both Vercel projects (finance, admin) — imported
- Admin env vars (Supabase URL/anon/service + ADMIN_EMAILS)
- Project↔domain attachments (zervo.app → finance w/ redirect, www → canonical, admin.zervo.app → admin)
- 9 DNS records: apex A, www + admin CNAMEs, 5 MX for Namecheap email forwarding, SPF TXT

## What's deliberately NOT in TF
- **Finance env vars**: too many to import right now, still managed in Vercel dashboard. Can migrate later if it becomes annoying.
- **Vercel's auto-records**: CAA (for cert issuance), ALIAS * and ALIAS @. Vercel creates and owns these — declaring them in TF would fight the provider.

## State storage
Local `infra/terraform.tfstate` (gitignored). Not a problem for a solo dev — and `terraform import` can rebuild it in ~5 min if the file is ever lost. If we want remote state later, swap to Terraform Cloud with `backend "remote"` + `terraform init -migrate-state`.

## Required manual step — final Namecheap visit
On Namecheap, change `zervo.app` nameservers from Namecheap's defaults to Vercel's:

1. Namecheap dashboard → Domain List → **Manage** `zervo.app`
2. **Nameservers** section → switch from **Namecheap BasicDNS** to **Custom DNS**
3. Enter:
   - `ns1.vercel-dns.com`
   - `ns2.vercel-dns.com`
4. Save. Propagation: 10 min – 24 hr (usually ~15 min).

Because Terraform already mirrored every Namecheap record into Vercel DNS, traffic continues resolving correctly the whole time — resolvers that still see Namecheap as authoritative get the old records, resolvers that see Vercel get identical records. No downtime.

Once the NS change lands, Namecheap's DNS tab can be emptied — every record lives in TF.

## Test plan
- [x] `terraform plan` shows no drift after apply
- [ ] After NS cutover, `dig NS zervo.app @8.8.8.8` shows the Vercel nameservers
- [ ] zervo.app, www.zervo.app, admin.zervo.app all still resolve + serve
- [ ] Adding a new subdomain via `terraform apply` works end-to-end