### PR TITLE
Infra: rename Vercel projects + path-based conditional deploys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,10 @@ Example: `apps/finance/src/app/api/budgets/route.js`
 
 ## Deployment
 
-- **apps/finance**: Vercel project `zentari-next` — Root Directory `apps/finance`. Auto-deploy on push to `main`. Domain: `zervo.app`.
-- **apps/admin**: Vercel project `zervo-admin` — Root Directory `apps/admin`. Auto-deploy on push to `main`. Domain: `admin.zervo.app`. Same Supabase backend as finance, gated by `ADMIN_EMAILS` allowlist at middleware. Google OAuth via `supabase.auth.signInWithOAuth` (same Supabase Google provider as finance). Page port in dev: `3001` (`pnpm dev:admin`).
+- **apps/finance**: Vercel project `finance-next` — Root Directory `apps/finance`. Auto-deploy on push to `main`. Domain: `zervo.app`.
+- **apps/admin**: Vercel project `finance-admin` — Root Directory `apps/admin`. Auto-deploy on push to `main`. Domain: `admin.zervo.app`. Same Supabase backend as finance, gated by `ADMIN_EMAILS` allowlist at middleware. Google OAuth via `supabase.auth.signInWithOAuth` (same Supabase Google provider as finance). Page port in dev: `3001` (`pnpm dev:admin`).
+
+**Conditional deploys:** Each project has an `ignore_command` (see `infra/vercel.tf`) so pushes only rebuild the project whose paths changed. A commit that touches only `apps/admin` doesn't rebuild finance; `packages/**` and root pnpm files trigger both. Infra-only or docs-only changes skip both.
 
 ## Database Migrations
 

--- a/infra/vercel.tf
+++ b/infra/vercel.tf
@@ -11,8 +11,16 @@
 #   terraform import vercel_project.admin   prj_0iPC1CHOb7puvOWTunkvRIAo242R
 # -----------------------------------------------------------------------------
 
+# Only redeploy when files this app actually cares about changed. Compares
+# against the last successful deploy's SHA (VERCEL_GIT_PREVIOUS_SHA); falls
+# back to HEAD^ if there's no previous deploy. Exit 0 = skip, exit 1 = deploy.
+locals {
+  finance_ignore = "git diff --quiet $${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD -- apps/finance packages pnpm-lock.yaml pnpm-workspace.yaml package.json"
+  admin_ignore   = "git diff --quiet $${VERCEL_GIT_PREVIOUS_SHA:-HEAD^} HEAD -- apps/admin packages pnpm-lock.yaml pnpm-workspace.yaml package.json"
+}
+
 resource "vercel_project" "finance" {
-  name      = "zentari-next"
+  name      = "finance-next"
   framework = "nextjs"
 
   root_directory = "apps/finance"
@@ -22,6 +30,9 @@ resource "vercel_project" "finance" {
     production_branch = "main"
   }
 
+  # Skip builds when only unrelated apps changed (e.g. apps/admin-only commits).
+  ignore_command = local.finance_ignore
+
   # Preview deploys require the Vercel login password (doesn't affect prod).
   vercel_authentication = {
     deployment_type = "standard_protection_new"
@@ -29,7 +40,7 @@ resource "vercel_project" "finance" {
 }
 
 resource "vercel_project" "admin" {
-  name      = "zervo-admin"
+  name      = "finance-admin"
   framework = "nextjs"
 
   root_directory = "apps/admin"
@@ -38,6 +49,8 @@ resource "vercel_project" "admin" {
     repo              = var.github_repo
     production_branch = "main"
   }
+
+  ignore_command = local.admin_ignore
 
   # Preview deploys require the Vercel login password (doesn't affect prod).
   vercel_authentication = {


### PR DESCRIPTION
## Summary

Two changes to `infra/vercel.tf`, applied via `terraform apply`:

1. **Renamed** `zentari-next` → `finance-next`, `zervo-admin` → `finance-admin`. Custom domains (zervo.app, admin.zervo.app) unaffected; only preview `*.vercel.app` URLs change.

2. **Path-based conditional deploys** — each project has an `ignore_command` that only rebuilds when its paths changed:
   - finance rebuilds on `apps/finance/**`, `packages/**`, root pnpm files
   - admin rebuilds on `apps/admin/**`, `packages/**`, root pnpm files
   - Infra-only, docs-only, or single-app commits skip the unrelated project

The command compares against the last deployed SHA (`VERCEL_GIT_PREVIOUS_SHA`) with a `HEAD^` fallback, so it behaves correctly on first deploys and long-running branches alike.

## Observable today

**This PR itself** only touches `infra/` and `CLAUDE.md` — so Vercel should skip BOTH builds. That's the first live test of the ignore command. Expect Vercel checks to say "build skipped" rather than "pass".