### PR TITLE
feat: admin impersonation + dashboard redesign

### DIFF
--- a/apps/admin/src/app/(admin)/page.tsx
+++ b/apps/admin/src/app/(admin)/page.tsx
@@ -12,18 +12,31 @@ type AccountRow = { item_id: string; type: string | null };
 
 export const dynamic = "force-dynamic";
 
-type RecentSignup = {
+type RecentlyOnlineUser = {
   id: string;
   email: string | null;
-  created_at: string | null;
+  last_active_at: string | null;
   first_name: string | null;
   last_name: string | null;
   avatar_url: string | null;
   tier: string;
 };
 
+const ONLINE_WINDOW_MS = 5 * 60 * 1000;
+const RECENT_WINDOW_MS = 60 * 60 * 1000;
+
+type Presence = "online" | "recent" | "offline";
+
+function presence(iso: string | null): Presence {
+  if (!iso) return "offline";
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < ONLINE_WINDOW_MS) return "online";
+  if (diff < RECENT_WINDOW_MS) return "recent";
+  return "offline";
+}
+
 function formatRelative(iso: string | null): string {
-  if (!iso) return "—";
+  if (!iso) return "never";
   const d = new Date(iso);
   const diff = Date.now() - d.getTime();
   const mins = Math.floor(diff / 60_000);
@@ -54,7 +67,6 @@ function initials(first: string | null, last: string | null, email: string | nul
 export default async function HomePage() {
   const admin = createAdminClient();
 
-  // Window boundaries for growth comparisons
   const now = new Date();
   const last7 = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
   const last30 = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
@@ -92,7 +104,7 @@ export default async function HomePage() {
     admin.auth.admin.listUsers({ page: 1, perPage: 200 }),
     admin
       .from("user_profiles")
-      .select("id, first_name, last_name, avatar_url, subscription_tier"),
+      .select("id, first_name, last_name, avatar_url, subscription_tier, last_active_at"),
     admin
       .from("plaid_items")
       .select(
@@ -114,35 +126,42 @@ export default async function HomePage() {
     last_name: string | null;
     avatar_url: string | null;
     subscription_tier: string | null;
+    last_active_at: string | null;
   };
   const profileById = new Map<string, ProfileRow>();
   for (const row of (profiles ?? []) as ProfileRow[]) {
     profileById.set(row.id, row);
   }
 
-  const sortedAuth = [...(authUsers?.users ?? [])].sort((a, b) => {
-    const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
-    const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
-    return tb - ta;
-  });
+  const authById = new Map<string, { email: string | null }>();
+  for (const u of authUsers?.users ?? []) {
+    authById.set(u.id, { email: u.email ?? null });
+  }
 
-  const recentSignups: RecentSignup[] = sortedAuth.slice(0, 6).map((u) => {
-    const p = profileById.get(u.id);
-    return {
-      id: u.id,
-      email: u.email ?? null,
-      created_at: u.created_at ?? null,
-      first_name: p?.first_name ?? null,
-      last_name: p?.last_name ?? null,
-      avatar_url: p?.avatar_url ?? null,
-      tier: p?.subscription_tier ?? "free",
-    };
-  });
-
+  const recentlyOnline: RecentlyOnlineUser[] = (profiles ?? [])
+    .filter((p): p is ProfileRow => Boolean((p as ProfileRow).last_active_at))
+    .sort((a, b) => {
+      const ta = new Date((a as ProfileRow).last_active_at!).getTime();
+      const tb = new Date((b as ProfileRow).last_active_at!).getTime();
+      return tb - ta;
+    })
+    .slice(0, 5)
+    .map((p) => {
+      const row = p as ProfileRow;
+      const auth = authById.get(row.id);
+      return {
+        id: row.id,
+        email: auth?.email ?? null,
+        last_active_at: row.last_active_at,
+        first_name: row.first_name,
+        last_name: row.last_name,
+        avatar_url: row.avatar_url,
+        tier: row.subscription_tier ?? "free",
+      };
+    });
 
   // Plaid cost aggregation. Billing is per Item per product; account types
-  // gate which products an Item is eligible for (an Item with only credit
-  // accounts shouldn't bill for Investments even if products includes it).
+  // gate which products an Item is eligible for.
   const plaidCostByUser = new Map<string, number>();
   let totalPlaidCost = 0;
   let totalPlaidItems = 0;
@@ -163,11 +182,11 @@ export default async function HomePage() {
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5)
     .map(([userId, cost]) => {
-      const authUser = sortedAuth.find((u) => u.id === userId);
+      const auth = authById.get(userId);
       const p = profileById.get(userId);
       return {
         id: userId,
-        email: authUser?.email ?? null,
+        email: auth?.email ?? null,
         first_name: p?.first_name ?? null,
         last_name: p?.last_name ?? null,
         avatar_url: p?.avatar_url ?? null,
@@ -187,11 +206,13 @@ export default async function HomePage() {
         : 0
       : Math.round(((growth30 - growthPrev) / growthPrev) * 100);
 
+  const onlineNow = recentlyOnline.filter((u) => presence(u.last_active_at) === "online").length;
+
   return (
     <>
       <AdminPageHeader title="Overview" subtitle="Internal state at a glance." />
 
-      <section className="grid grid-cols-2 md:grid-cols-4 gap-x-10 gap-y-8 mb-14">
+      <section className="grid grid-cols-2 md:grid-cols-4 gap-x-10 gap-y-8 mb-16">
         <Stat
           label="Users"
           value={totalUsers}
@@ -211,6 +232,15 @@ export default async function HomePage() {
           }
         />
         <Stat
+          label="Active · 7d"
+          value={activeLast7 ?? 0}
+          sub={
+            <span className="text-[var(--color-muted)]/80 tabular-nums">
+              {onlineNow > 0 ? `${onlineNow} online now` : "used the app recently"}
+            </span>
+          }
+        />
+        <Stat
           label="Plaid · est."
           value={`${formatUsd(totalPlaidCost)}`}
           sub={
@@ -220,18 +250,13 @@ export default async function HomePage() {
             </span>
           }
         />
-        <Stat
-          label="Active · 7d"
-          value={activeLast7 ?? 0}
-          sub={<span className="text-[var(--color-muted)]/80">used the app recently</span>}
-        />
       </section>
 
       <div className="grid grid-cols-1 lg:grid-cols-[1.4fr_1fr] gap-x-12 gap-y-12">
         <section>
           <div className="flex items-baseline justify-between mb-3">
             <h2 className="text-xs font-medium uppercase tracking-[0.08em] text-[var(--color-muted)]/60">
-              Recent signups
+              Recently online
             </h2>
             <Link
               href="/users"
@@ -241,37 +266,51 @@ export default async function HomePage() {
             </Link>
           </div>
           <ul className="divide-y divide-[var(--color-fg)]/[0.06] border-t border-b border-[var(--color-fg)]/[0.06]">
-            {recentSignups.length === 0 ? (
-              <li className="py-4 text-sm text-[var(--color-muted)]">No signups yet.</li>
+            {recentlyOnline.length === 0 ? (
+              <li className="py-4 text-sm text-[var(--color-muted)]">
+                No active users yet.
+              </li>
             ) : (
-              recentSignups.map((u) => (
-                <li key={u.id}>
-                  <div className="flex items-center gap-3 py-3">
-                    <Avatar
-                      url={u.avatar_url}
-                      initials={initials(u.first_name, u.last_name, u.email)}
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-baseline gap-2">
-                        <span className="text-sm text-[var(--color-fg)] truncate">
-                          {fullName(u.first_name, u.last_name, u.email)}
-                        </span>
-                        {u.tier === "pro" && (
-                          <span className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-accent)] font-medium">
-                            pro
+              recentlyOnline.map((u) => {
+                const p = presence(u.last_active_at);
+                return (
+                  <li key={u.id}>
+                    <div className="flex items-center gap-3 py-3.5">
+                      <Avatar
+                        url={u.avatar_url}
+                        initials={initials(u.first_name, u.last_name, u.email)}
+                        presence={p}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-[var(--color-fg)] truncate">
+                            {fullName(u.first_name, u.last_name, u.email)}
                           </span>
-                        )}
+                          {u.tier === "pro" && (
+                            <span className="text-[10px] uppercase tracking-[0.08em] text-[var(--color-accent)] font-semibold">
+                              pro
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-xs text-[var(--color-muted)] truncate leading-tight mt-0.5">
+                          {u.email ?? "—"}
+                        </div>
                       </div>
-                      <div className="text-xs text-[var(--color-muted)] truncate">
-                        {u.email ?? "—"}
+                      <div className="flex flex-col items-end flex-shrink-0">
+                        <span
+                          className={
+                            p === "online"
+                              ? "text-xs font-medium text-[var(--color-success)]"
+                              : "text-xs text-[var(--color-muted)] tabular-nums"
+                          }
+                        >
+                          {p === "online" ? "online" : formatRelative(u.last_active_at)}
+                        </span>
                       </div>
                     </div>
-                    <span className="text-xs text-[var(--color-muted)] tabular-nums flex-shrink-0">
-                      {formatRelative(u.created_at)}
-                    </span>
-                  </div>
-                </li>
-              ))
+                  </li>
+                );
+              })
             )}
           </ul>
         </section>
@@ -312,14 +351,6 @@ export default async function HomePage() {
               ))}
             </ul>
           )}
-
-          <h2 className="text-xs font-medium uppercase tracking-[0.08em] text-[var(--color-muted)]/60 mb-3 mt-10">
-            Quick actions
-          </h2>
-          <ul className="divide-y divide-[var(--color-fg)]/[0.06] border-t border-b border-[var(--color-fg)]/[0.06]">
-            <QuickLink href="/users" label="Browse users" />
-            <QuickLink href="/settings" label="Admin settings" />
-          </ul>
         </section>
       </div>
     </>
@@ -371,13 +402,33 @@ function DeltaPill({ value }: { value: number }) {
   );
 }
 
-function Avatar({ url, initials }: { url: string | null; initials: string }) {
+function Avatar({
+  url,
+  initials,
+  presence: p,
+}: {
+  url: string | null;
+  initials: string;
+  presence?: Presence;
+}) {
   return (
-    <div className="relative h-8 w-8 flex-shrink-0 rounded-full bg-[var(--color-accent)] flex items-center justify-center overflow-hidden text-[11px] font-semibold text-[var(--color-on-accent)]">
+    <div className="relative h-9 w-9 flex-shrink-0 rounded-full bg-[var(--color-accent)] flex items-center justify-center overflow-hidden text-[11px] font-semibold text-[var(--color-on-accent)]">
       {url ? (
         <img src={url} alt="" className="h-full w-full object-cover" />
       ) : (
         <span>{initials}</span>
+      )}
+      {p === "online" && (
+        <span
+          aria-hidden
+          className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-[var(--color-success)] ring-2 ring-[var(--color-content-bg)]"
+        />
+      )}
+      {p === "recent" && (
+        <span
+          aria-hidden
+          className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-[#d97706] ring-2 ring-[var(--color-content-bg)]"
+        />
       )}
     </div>
   );
@@ -409,21 +460,5 @@ function TierBar({ pro, total }: { pro: number; total: number }) {
         <span className="tabular-nums text-[var(--color-fg)]">{pro}</span>
       </div>
     </div>
-  );
-}
-
-function QuickLink({ href, label }: { href: string; label: string }) {
-  return (
-    <li>
-      <Link
-        href={href}
-        className="group flex items-center justify-between py-3 text-sm text-[var(--color-fg)] transition-colors hover:text-[var(--color-accent)]"
-      >
-        <span>{label}</span>
-        <span className="text-[var(--color-muted)] transition-colors group-hover:text-[var(--color-accent)]">
-          ›
-        </span>
-      </Link>
-    </li>
   );
 }

--- a/apps/admin/src/app/(admin)/users/UserDrawer.tsx
+++ b/apps/admin/src/app/(admin)/users/UserDrawer.tsx
@@ -146,6 +146,30 @@ export default function UserDrawer({
     }
   }
 
+  async function enterSession(grantId: string) {
+    setGrantBusy(true);
+    setGrantError(null);
+    try {
+      const res = await fetch(
+        `/api/impersonation/${encodeURIComponent(grantId)}/start`,
+        { method: "POST" },
+      );
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Could not start session");
+      const link = body?.action_link as string | undefined;
+      if (!link) throw new Error("No magic link returned");
+      // Open in a new tab so the admin app stays signed in as me. The
+      // new tab follows the magic link, mints a session as the target,
+      // and lands on /dashboard with the impersonation banner showing.
+      window.open(link, "_blank", "noopener,noreferrer");
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setGrantError(err?.message || "Could not start session");
+    } finally {
+      setGrantBusy(false);
+    }
+  }
+
   async function cancelImpersonation(grantId: string) {
     setGrantBusy(true);
     setGrantError(null);
@@ -421,10 +445,10 @@ export default function UserDrawer({
                       <Button
                         variant="secondary"
                         size="sm"
-                        disabled
-                        title="Enter session — coming next commit"
+                        onClick={() => enterSession(openGrant.id)}
+                        disabled={grantBusy}
                       >
-                        Enter session
+                        {grantBusy ? "Opening…" : "Enter session"}
                       </Button>
                       <Button
                         variant="dangerSubtle"

--- a/apps/admin/src/app/(admin)/users/UserDrawer.tsx
+++ b/apps/admin/src/app/(admin)/users/UserDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, ConfirmOverlay, Drawer } from "@zervo/ui";
 import { billableLinesForItem, formatUsd } from "@/lib/plaidPricing";
 import {
@@ -10,6 +10,36 @@ import {
   fullName,
   initials,
 } from "./UsersClient";
+
+type Grant = {
+  id: string;
+  status: string;
+  expires_at: string | null;
+  decided_at: string | null;
+  duration_seconds: number;
+  requested_at: string;
+  reason: string | null;
+};
+
+function isActive(g: Grant): boolean {
+  return g.status === "approved" && !!g.expires_at && new Date(g.expires_at).getTime() > Date.now();
+}
+
+function isOpen(g: Grant): boolean {
+  return g.status === "pending" || isActive(g);
+}
+
+function formatExpiresIn(iso: string | null): string {
+  if (!iso) return "—";
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return "expired";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
 
 type Props = {
   user: AdminUserRow | null;
@@ -38,8 +68,106 @@ export default function UserDrawer({
   const [subBusy, setSubBusy] = useState(false);
   const [subError, setSubError] = useState<string | null>(null);
 
+  const [grants, setGrants] = useState<Grant[] | null>(null);
+  const [grantsLoading, setGrantsLoading] = useState(false);
+  const [grantBusy, setGrantBusy] = useState(false);
+  const [grantError, setGrantError] = useState<string | null>(null);
+  const [duration, setDuration] = useState<number>(86_400);
+  const [reason, setReason] = useState("");
+
   const isPro = user?.subscription_tier === "pro";
   const status = user?.subscription_status;
+  const openGrant = grants?.find((g) => isOpen(g)) ?? null;
+  const lastGrant = grants?.[0] ?? null;
+
+  useEffect(() => {
+    if (!user) {
+      setGrants(null);
+      setGrantError(null);
+      setReason("");
+      return;
+    }
+    let cancelled = false;
+    setGrantsLoading(true);
+    setGrantError(null);
+    fetch(`/api/impersonation?target=${encodeURIComponent(user.id)}`, { cache: "no-store" })
+      .then(async (res) => {
+        const body = await res.json().catch(() => ({}));
+        if (cancelled) return;
+        if (!res.ok) {
+          setGrantError(body?.error || "Could not load grants");
+          setGrants([]);
+          return;
+        }
+        setGrants((body?.grants as Grant[]) ?? []);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setGrantError(e?.message || "Could not load grants");
+        setGrants([]);
+      })
+      .finally(() => {
+        if (!cancelled) setGrantsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  async function requestImpersonation() {
+    if (!user) return;
+    setGrantBusy(true);
+    setGrantError(null);
+    try {
+      const res = await fetch(`/api/impersonation`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          target_user_id: user.id,
+          duration_seconds: duration,
+          reason: reason.trim() || undefined,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body?.error || "Request failed");
+      const newGrant = body.grant as Grant | undefined;
+      if (newGrant) {
+        setGrants((prev) => {
+          const others = (prev ?? []).filter((g) => g.id !== newGrant.id);
+          return [newGrant, ...others];
+        });
+        setReason("");
+      }
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setGrantError(err?.message || "Request failed");
+    } finally {
+      setGrantBusy(false);
+    }
+  }
+
+  async function cancelImpersonation(grantId: string) {
+    setGrantBusy(true);
+    setGrantError(null);
+    try {
+      const res = await fetch(`/api/impersonation/${encodeURIComponent(grantId)}`, {
+        method: "DELETE",
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body?.error || "Cancel failed");
+      const updated = body.grant as Grant | undefined;
+      if (updated) {
+        setGrants((prev) =>
+          (prev ?? []).map((g) => (g.id === updated.id ? updated : g)),
+        );
+      }
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setGrantError(err?.message || "Cancel failed");
+    } finally {
+      setGrantBusy(false);
+    }
+  }
 
   async function handleDelete() {
     if (!user) return;
@@ -249,6 +377,110 @@ export default function UserDrawer({
                     );
                   })}
                 </ul>
+              )}
+            </section>
+
+            <section>
+              <h3 className="text-[11px] uppercase tracking-[0.08em] text-[var(--color-muted)]/60 mb-3">
+                Impersonation
+              </h3>
+              <div className="border-t border-b border-[var(--color-fg)]/[0.06] py-4 space-y-3">
+                {grantsLoading && !grants ? (
+                  <div className="text-xs text-[var(--color-muted)]">Loading…</div>
+                ) : openGrant && openGrant.status === "pending" ? (
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-sm text-[var(--color-fg)]">
+                        Pending — awaiting user approval
+                      </div>
+                      <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
+                        Requested {formatRelative(openGrant.requested_at)} ·{" "}
+                        {Math.round(openGrant.duration_seconds / 3600)}h grant
+                      </div>
+                    </div>
+                    <Button
+                      variant="dangerSubtle"
+                      size="sm"
+                      onClick={() => cancelImpersonation(openGrant.id)}
+                      disabled={grantBusy}
+                    >
+                      {grantBusy ? "Canceling…" : "Cancel"}
+                    </Button>
+                  </div>
+                ) : openGrant && isActive(openGrant) ? (
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="text-sm text-[var(--color-success)] font-medium">
+                        Active — expires in {formatExpiresIn(openGrant.expires_at)}
+                      </div>
+                      <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
+                        Approved {formatRelative(openGrant.decided_at)}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        disabled
+                        title="Enter session — coming next commit"
+                      >
+                        Enter session
+                      </Button>
+                      <Button
+                        variant="dangerSubtle"
+                        size="sm"
+                        onClick={() => cancelImpersonation(openGrant.id)}
+                        disabled={grantBusy}
+                      >
+                        Revoke
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {lastGrant && (
+                      <div className="text-[11px] text-[var(--color-muted)]">
+                        Last request: {lastGrant.status} ·{" "}
+                        {formatRelative(lastGrant.decided_at ?? lastGrant.requested_at)}
+                      </div>
+                    )}
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <label className="text-[11px] text-[var(--color-muted)]/70 uppercase tracking-[0.08em]">
+                        Duration
+                      </label>
+                      <select
+                        value={duration}
+                        onChange={(e) => setDuration(Number(e.target.value))}
+                        className="bg-[var(--color-input-bg)] text-[var(--color-input-fg)] text-xs rounded px-2 py-1 outline-none"
+                        disabled={grantBusy}
+                      >
+                        <option value={3_600}>1 hour</option>
+                        <option value={86_400}>24 hours</option>
+                        <option value={604_800}>7 days</option>
+                      </select>
+                    </div>
+                    <input
+                      type="text"
+                      value={reason}
+                      onChange={(e) => setReason(e.target.value)}
+                      placeholder="Reason (optional, shown to user)"
+                      maxLength={500}
+                      disabled={grantBusy}
+                      className="w-full bg-[var(--color-input-bg)] text-[var(--color-input-fg)] text-xs rounded px-2 py-1.5 outline-none placeholder:text-[var(--color-input-placeholder)]"
+                    />
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={requestImpersonation}
+                      disabled={grantBusy}
+                    >
+                      {grantBusy ? "Requesting…" : "Request access"}
+                    </Button>
+                  </div>
+                )}
+              </div>
+              {grantError && (
+                <p className="mt-2 text-xs text-[var(--color-danger)]/80">{grantError}</p>
               )}
             </section>
 

--- a/apps/admin/src/app/api/impersonation/[id]/route.ts
+++ b/apps/admin/src/app/api/impersonation/[id]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isAllowedAdmin } from "@/lib/auth/admin";
+
+function getFinanceApiUrl(): string {
+  return process.env.FINANCE_API_URL || "https://www.zervo.app";
+}
+
+async function resolveAdmin() {
+  const supabase = await createClient();
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData?.user) return { ok: false as const, status: 401, error: "No admin session" };
+  if (!isAllowedAdmin(userData.user.email)) {
+    return { ok: false as const, status: 403, error: "Not on admin allowlist" };
+  }
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return { ok: false as const, status: 401, error: "Admin session has no access_token" };
+  }
+  return { ok: true as const, accessToken: session.access_token };
+}
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function DELETE(_req: NextRequest, ctx: RouteContext) {
+  const admin = await resolveAdmin();
+  if (!admin.ok) return NextResponse.json({ error: admin.error }, { status: admin.status });
+
+  const { id } = await ctx.params;
+  const res = await fetch(
+    `${getFinanceApiUrl()}/api/admin/impersonation/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${admin.accessToken}` },
+      cache: "no-store",
+    },
+  );
+
+  const json = await res.json().catch(() => ({}));
+  return NextResponse.json(json, { status: res.status });
+}

--- a/apps/admin/src/app/api/impersonation/[id]/start/route.ts
+++ b/apps/admin/src/app/api/impersonation/[id]/start/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isAllowedAdmin } from "@/lib/auth/admin";
+
+function getFinanceApiUrl(): string {
+  return process.env.FINANCE_API_URL || "https://www.zervo.app";
+}
+
+async function resolveAdmin() {
+  const supabase = await createClient();
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData?.user) return { ok: false as const, status: 401, error: "No admin session" };
+  if (!isAllowedAdmin(userData.user.email)) {
+    return { ok: false as const, status: 403, error: "Not on admin allowlist" };
+  }
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return { ok: false as const, status: 401, error: "Admin session has no access_token" };
+  }
+  return { ok: true as const, accessToken: session.access_token };
+}
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(req: NextRequest, ctx: RouteContext) {
+  const admin = await resolveAdmin();
+  if (!admin.ok) return NextResponse.json({ error: admin.error }, { status: admin.status });
+
+  const { id } = await ctx.params;
+  const res = await fetch(
+    `${getFinanceApiUrl()}/api/admin/impersonation/${encodeURIComponent(id)}/start`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${admin.accessToken}`,
+        // Pass the admin's request origin/UA through so finance can log it
+        // on the impersonation_sessions row.
+        "x-forwarded-for":
+          req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip") ?? "",
+        "user-agent": req.headers.get("user-agent") ?? "",
+      },
+      cache: "no-store",
+    },
+  );
+
+  const json = await res.json().catch(() => ({}));
+  return NextResponse.json(json, { status: res.status });
+}

--- a/apps/admin/src/app/api/impersonation/route.ts
+++ b/apps/admin/src/app/api/impersonation/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isAllowedAdmin } from "@/lib/auth/admin";
+
+function getFinanceApiUrl(): string {
+  // zervo.app 301-redirects to www.zervo.app and undici strips the
+  // Authorization header across redirects, so always hit the canonical
+  // host directly.
+  return process.env.FINANCE_API_URL || "https://www.zervo.app";
+}
+
+async function resolveAdmin(): Promise<
+  | { ok: true; userId: string; email: string; accessToken: string }
+  | { ok: false; status: number; error: string }
+> {
+  const supabase = await createClient();
+  const { data: userData, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !userData?.user) {
+    return { ok: false, status: 401, error: "No admin session" };
+  }
+  if (!isAllowedAdmin(userData.user.email)) {
+    return { ok: false, status: 403, error: "Not on admin allowlist" };
+  }
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return { ok: false, status: 401, error: "Admin session has no access_token" };
+  }
+  return {
+    ok: true,
+    userId: userData.user.id,
+    email: userData.user.email ?? "",
+    accessToken: session.access_token,
+  };
+}
+
+export async function POST(req: NextRequest) {
+  const admin = await resolveAdmin();
+  if (!admin.ok) return NextResponse.json({ error: admin.error }, { status: admin.status });
+
+  const body = await req.json().catch(() => ({}));
+  const res = await fetch(`${getFinanceApiUrl()}/api/admin/impersonation`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${admin.accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  const json = await res.json().catch(() => ({}));
+  return NextResponse.json(json, { status: res.status });
+}
+
+export async function GET(req: NextRequest) {
+  const admin = await resolveAdmin();
+  if (!admin.ok) return NextResponse.json({ error: admin.error }, { status: admin.status });
+
+  const target = req.nextUrl.searchParams.get("target");
+  if (!target) {
+    return NextResponse.json({ error: "target query param required" }, { status: 400 });
+  }
+
+  const res = await fetch(
+    `${getFinanceApiUrl()}/api/admin/impersonation?target=${encodeURIComponent(target)}`,
+    {
+      headers: { Authorization: `Bearer ${admin.accessToken}` },
+      cache: "no-store",
+    },
+  );
+
+  const json = await res.json().catch(() => ({}));
+  return NextResponse.json(json, { status: res.status });
+}

--- a/apps/finance/src/app/(main)/settings/support-access/page.tsx
+++ b/apps/finance/src/app/(main)/settings/support-access/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import PageContainer from "../../../../components/layout/PageContainer";
+import { authFetch } from "../../../../lib/api/fetch";
+
+type Grant = {
+  id: string;
+  status: string;
+  expires_at: string | null;
+  decided_at: string | null;
+  duration_seconds: number;
+  requested_at: string;
+  reason: string | null;
+  requester_id: string;
+  requester_email: string | null;
+};
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  const diff = Date.now() - d.getTime();
+  const past = diff >= 0;
+  const abs = Math.abs(diff);
+  const mins = Math.floor(abs / 60_000);
+  if (mins < 1) return past ? "just now" : "now";
+  if (mins < 60) return past ? `${mins}m ago` : `in ${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return past ? `${hours}h ago` : `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return past ? `${days}d ago` : `in ${days}d`;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function isActive(g: Grant): boolean {
+  return g.status === "approved" && !!g.expires_at && new Date(g.expires_at).getTime() > Date.now();
+}
+
+const STATUS_COPY: Record<string, string> = {
+  pending: "Pending",
+  approved: "Active",
+  denied: "Denied",
+  revoked: "Revoked",
+  expired: "Expired",
+};
+
+export default function SupportAccessPage() {
+  const [grants, setGrants] = useState<Grant[] | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    try {
+      const res = await authFetch("/api/account/impersonation?all=1");
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Could not load");
+      setGrants((body?.grants as Grant[]) ?? []);
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setError(err?.message || "Could not load");
+      setGrants([]);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function decide(id: string, action: "approve" | "deny" | "revoke") {
+    setBusyId(id);
+    setError(null);
+    try {
+      const res = await authFetch(`/api/account/impersonation/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body?.error || "Failed");
+      const updated = body?.grant as Grant | undefined;
+      if (updated) {
+        setGrants((prev) =>
+          (prev ?? []).map((g) => (g.id === updated.id ? { ...g, ...updated } : g)),
+        );
+      }
+    } catch (e: unknown) {
+      const err = e as { message?: string };
+      setError(err?.message || "Failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const sorted = (grants ?? []).slice().sort((a, b) => {
+    // Open (pending or active) first, then by requested_at desc.
+    const aOpen = a.status === "pending" || isActive(a) ? 1 : 0;
+    const bOpen = b.status === "pending" || isActive(b) ? 1 : 0;
+    if (aOpen !== bOpen) return bOpen - aOpen;
+    return new Date(b.requested_at).getTime() - new Date(a.requested_at).getTime();
+  });
+
+  return (
+    <PageContainer title="Support access">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <p className="text-sm text-[var(--color-muted)]">
+          Admins can request temporary access to your account for support. Approve only
+          if you trust the requester — they&apos;ll be able to see and act in your
+          account until the grant expires or you revoke it.{" "}
+          <Link href="/settings" className="underline hover:no-underline">
+            Back to settings
+          </Link>
+        </p>
+
+        {error && (
+          <div className="text-xs text-[var(--color-danger)]/80">{error}</div>
+        )}
+
+        {grants === null ? (
+          <div className="text-sm text-[var(--color-muted)]">Loading…</div>
+        ) : sorted.length === 0 ? (
+          <div className="text-sm text-[var(--color-muted)] py-8 text-center border-t border-b border-[var(--color-fg)]/[0.06]">
+            No requests yet.
+          </div>
+        ) : (
+          <ul className="divide-y divide-[var(--color-fg)]/[0.06] border-t border-b border-[var(--color-fg)]/[0.06]">
+            {sorted.map((g) => {
+              const active = isActive(g);
+              const open = g.status === "pending" || active;
+              return (
+                <li key={g.id} className="py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-[var(--color-fg)] truncate">
+                          {g.requester_email ?? "Unknown admin"}
+                        </span>
+                        <span
+                          className={
+                            active
+                              ? "text-[10px] uppercase tracking-[0.08em] font-semibold text-[var(--color-success)]"
+                              : g.status === "pending"
+                                ? "text-[10px] uppercase tracking-[0.08em] font-semibold text-[var(--color-accent)]"
+                                : "text-[10px] uppercase tracking-[0.08em] text-[var(--color-muted)]/70"
+                          }
+                        >
+                          {STATUS_COPY[g.status] ?? g.status}
+                        </span>
+                      </div>
+                      {g.reason && (
+                        <div className="text-xs text-[var(--color-muted)] mt-0.5 italic">
+                          “{g.reason}”
+                        </div>
+                      )}
+                      <div className="text-[11px] text-[var(--color-muted)]/70 mt-1">
+                        Requested {formatRelative(g.requested_at)}
+                        {g.decided_at && (
+                          <>
+                            {" · "}
+                            {g.status === "approved" ? "approved" : g.status}{" "}
+                            {formatRelative(g.decided_at)}
+                          </>
+                        )}
+                        {active && g.expires_at && <> · expires {formatRelative(g.expires_at)}</>}
+                      </div>
+                    </div>
+                    {open && (
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        {g.status === "pending" ? (
+                          <>
+                            <button
+                              onClick={() => decide(g.id, "approve")}
+                              disabled={busyId === g.id}
+                              className="text-xs font-medium px-2.5 py-1 rounded bg-[var(--color-accent)] text-[var(--color-on-accent)] hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
+                            >
+                              {busyId === g.id ? "…" : "Approve"}
+                            </button>
+                            <button
+                              onClick={() => decide(g.id, "deny")}
+                              disabled={busyId === g.id}
+                              className="text-xs font-medium text-[var(--color-fg)] hover:underline disabled:opacity-50"
+                            >
+                              Deny
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            onClick={() => decide(g.id, "revoke")}
+                            disabled={busyId === g.id}
+                            className="text-xs font-medium text-[var(--color-danger)] hover:underline disabled:opacity-50"
+                          >
+                            {busyId === g.id ? "…" : "Revoke"}
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/finance/src/app/api/account/delete/route.ts
+++ b/apps/finance/src/app/api/account/delete/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "../../../../lib/api/withAuth";
 import { deleteUserCompletely } from "../../../../lib/accountDeletion/deleteUserCompletely";
+import { blockedByImpersonation } from "../../../../lib/impersonation/guard";
 
-export const POST = withAuth("account:delete", async (_req, userId) => {
+export const POST = withAuth("account:delete", async (req, userId) => {
+  const blocked = await blockedByImpersonation(req);
+  if (blocked) return blocked;
+
   const result = await deleteUserCompletely(userId);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: result.status });

--- a/apps/finance/src/app/api/account/impersonation/[id]/route.ts
+++ b/apps/finance/src/app/api/account/impersonation/[id]/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAuth } from "../../../../../lib/api/withAuth";
+import { supabaseAdmin } from "../../../../../lib/supabase/admin";
+
+/**
+ * Target user approves, denies, or revokes a grant aimed at them. State
+ * machine:
+ *   pending  → approved (sets expires_at = now + duration)
+ *   pending  → denied
+ *   approved → revoked
+ * Anything else is rejected — re-requesting goes through the admin path.
+ */
+export const PATCH = withAuth<{ id: string }>(
+  "account:impersonation:decide",
+  async (req: NextRequest, callerId, { params }) => {
+    const { id: grantId } = await params;
+    if (!grantId) {
+      return NextResponse.json({ error: "Missing grant id" }, { status: 400 });
+    }
+
+    const body = (await req.json().catch(() => ({}))) as { action?: string };
+    const action = body.action;
+    if (action !== "approve" && action !== "deny" && action !== "revoke") {
+      return NextResponse.json(
+        { error: "action must be approve | deny | revoke" },
+        { status: 400 },
+      );
+    }
+
+    const { data: grant, error: fetchErr } = await supabaseAdmin
+      .from("impersonation_grants")
+      .select("id, status, target_user_id, duration_seconds")
+      .eq("id", grantId)
+      .single();
+
+    if (fetchErr || !grant) {
+      return NextResponse.json({ error: "Grant not found" }, { status: 404 });
+    }
+    if (grant.target_user_id !== callerId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (action === "approve") {
+      if (grant.status !== "pending") {
+        return NextResponse.json(
+          { error: `Cannot approve a ${grant.status} grant` },
+          { status: 400 },
+        );
+      }
+      const now = new Date();
+      const expires = new Date(now.getTime() + grant.duration_seconds * 1000);
+      const { data: updated, error } = await supabaseAdmin
+        .from("impersonation_grants")
+        .update({
+          status: "approved",
+          decided_at: now.toISOString(),
+          expires_at: expires.toISOString(),
+        })
+        .eq("id", grantId)
+        .select(
+          "id, status, expires_at, decided_at, duration_seconds, requested_at, reason, requester_id",
+        )
+        .single();
+      if (error || !updated) {
+        console.error("[account:impersonation:decide] approve failed", error);
+        return NextResponse.json({ error: "Could not approve" }, { status: 500 });
+      }
+      return NextResponse.json({ grant: updated });
+    }
+
+    if (action === "deny") {
+      if (grant.status !== "pending") {
+        return NextResponse.json(
+          { error: `Cannot deny a ${grant.status} grant` },
+          { status: 400 },
+        );
+      }
+      const { data: updated, error } = await supabaseAdmin
+        .from("impersonation_grants")
+        .update({ status: "denied", decided_at: new Date().toISOString() })
+        .eq("id", grantId)
+        .select(
+          "id, status, expires_at, decided_at, duration_seconds, requested_at, reason, requester_id",
+        )
+        .single();
+      if (error || !updated) {
+        console.error("[account:impersonation:decide] deny failed", error);
+        return NextResponse.json({ error: "Could not deny" }, { status: 500 });
+      }
+      return NextResponse.json({ grant: updated });
+    }
+
+    // revoke
+    if (grant.status !== "approved") {
+      return NextResponse.json(
+        { error: `Cannot revoke a ${grant.status} grant` },
+        { status: 400 },
+      );
+    }
+    const { data: updated, error } = await supabaseAdmin
+      .from("impersonation_grants")
+      .update({ status: "revoked", decided_at: new Date().toISOString() })
+      .eq("id", grantId)
+      .select(
+        "id, status, expires_at, decided_at, duration_seconds, requested_at, reason, requester_id",
+      )
+      .single();
+    if (error || !updated) {
+      console.error("[account:impersonation:decide] revoke failed", error);
+      return NextResponse.json({ error: "Could not revoke" }, { status: 500 });
+    }
+    return NextResponse.json({ grant: updated });
+  },
+);

--- a/apps/finance/src/app/api/account/impersonation/route.ts
+++ b/apps/finance/src/app/api/account/impersonation/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAuth } from "../../../../lib/api/withAuth";
+import { supabaseAdmin } from "../../../../lib/supabase/admin";
+
+/**
+ * The current user lists impersonation grants targeting them — pending
+ * requests that need a decision and active grants they may want to
+ * revoke. The settings page also uses this to show full history.
+ */
+export const GET = withAuth("account:impersonation:list", async (req: NextRequest, callerId) => {
+  const includeAll = req.nextUrl.searchParams.get("all") === "1";
+
+  let query = supabaseAdmin
+    .from("impersonation_grants")
+    .select("id, status, expires_at, decided_at, duration_seconds, requested_at, reason, requester_id")
+    .eq("target_user_id", callerId)
+    .order("requested_at", { ascending: false });
+
+  if (!includeAll) {
+    query = query.in("status", ["pending", "approved"]).limit(10);
+  } else {
+    query = query.limit(50);
+  }
+
+  const { data: grants, error } = await query;
+  if (error) {
+    console.error("[account:impersonation:list] query failed", error);
+    return NextResponse.json({ error: "Could not load grants" }, { status: 500 });
+  }
+
+  // Hydrate requester emails so the banner can say "Adarsh is requesting…".
+  // Do this server-side because clients can't read auth.users for non-self.
+  const requesterIds = Array.from(new Set((grants ?? []).map((g) => g.requester_id)));
+  const requesterById: Record<string, { email: string | null }> = {};
+  for (const id of requesterIds) {
+    const { data } = await supabaseAdmin.auth.admin.getUserById(id);
+    requesterById[id] = { email: data?.user?.email ?? null };
+  }
+
+  const enriched = (grants ?? []).map((g) => ({
+    ...g,
+    requester_email: requesterById[g.requester_id]?.email ?? null,
+  }));
+
+  return NextResponse.json({ grants: enriched });
+});

--- a/apps/finance/src/app/api/admin/impersonation/[id]/route.ts
+++ b/apps/finance/src/app/api/admin/impersonation/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "../../../../../lib/api/withAuth";
+import { isCallerAdmin } from "../../../../../lib/api/admin";
+import { supabaseAdmin } from "../../../../../lib/supabase/admin";
+
+/**
+ * Admin cancels their own pending request, or revokes their own active
+ * grant. We don't let admins act on grants they didn't create — the
+ * `requester_id` check is the access boundary. Targets revoke through a
+ * separate user-facing endpoint, not this one.
+ */
+export const DELETE = withAuth<{ id: string }>(
+  "admin:impersonation:cancel",
+  async (_req, callerId, { params }) => {
+    if (!(await isCallerAdmin(callerId))) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id: grantId } = await params;
+    if (!grantId) {
+      return NextResponse.json({ error: "Missing grant id" }, { status: 400 });
+    }
+
+    const { data: grant, error: fetchErr } = await supabaseAdmin
+      .from("impersonation_grants")
+      .select("id, status, requester_id")
+      .eq("id", grantId)
+      .single();
+
+    if (fetchErr || !grant) {
+      return NextResponse.json({ error: "Grant not found" }, { status: 404 });
+    }
+    if (grant.requester_id !== callerId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (grant.status === "denied" || grant.status === "expired" || grant.status === "revoked") {
+      return NextResponse.json({ error: `Grant already ${grant.status}` }, { status: 400 });
+    }
+
+    // We use "revoked" as the terminal state for both target and admin
+    // cancellations — the audit trail (who decided_at when) and the
+    // session log distinguish who took the action if it ever matters.
+    const { data: updated, error: updErr } = await supabaseAdmin
+      .from("impersonation_grants")
+      .update({ status: "revoked", decided_at: new Date().toISOString() })
+      .eq("id", grantId)
+      .select("id, status, expires_at, decided_at, duration_seconds, requested_at, reason")
+      .single();
+
+    if (updErr || !updated) {
+      console.error("[admin:impersonation:cancel] update failed", updErr);
+      return NextResponse.json({ error: "Could not cancel grant" }, { status: 500 });
+    }
+
+    return NextResponse.json({ grant: updated });
+  },
+);

--- a/apps/finance/src/app/api/admin/impersonation/[id]/start/route.ts
+++ b/apps/finance/src/app/api/admin/impersonation/[id]/start/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAuth } from "../../../../../../lib/api/withAuth";
+import { isCallerAdmin } from "../../../../../../lib/api/admin";
+import { supabaseAdmin } from "../../../../../../lib/supabase/admin";
+
+/**
+ * Admin clicks "Enter session" → finance creates an impersonation_sessions
+ * row (intent token, consumed_at = null) and generates a one-time Supabase
+ * magic link for the target user. The admin's browser opens the action_link
+ * in a new tab; Supabase verifies + mints a session as the target, then
+ * redirects through `/auth/callback?next=/impersonation/begin?session=<id>`
+ * which sets the impersonator cookie and lands on the dashboard.
+ *
+ * The session_id is the row's uuid, which is hard to guess and only valid
+ * once (we set consumed_at on /api/impersonation/begin so a leaked URL
+ * can't be replayed).
+ */
+export const POST = withAuth<{ id: string }>(
+  "admin:impersonation:start",
+  async (req: NextRequest, callerId, { params }) => {
+    if (!(await isCallerAdmin(callerId))) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { id: grantId } = await params;
+    if (!grantId) {
+      return NextResponse.json({ error: "Missing grant id" }, { status: 400 });
+    }
+
+    const { data: grant, error: fetchErr } = await supabaseAdmin
+      .from("impersonation_grants")
+      .select("id, status, expires_at, requester_id, target_user_id")
+      .eq("id", grantId)
+      .single();
+
+    if (fetchErr || !grant) {
+      return NextResponse.json({ error: "Grant not found" }, { status: 404 });
+    }
+    if (grant.requester_id !== callerId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (grant.status !== "approved") {
+      return NextResponse.json({ error: `Grant is ${grant.status}` }, { status: 400 });
+    }
+    if (!grant.expires_at || new Date(grant.expires_at).getTime() < Date.now()) {
+      return NextResponse.json({ error: "Grant has expired" }, { status: 400 });
+    }
+
+    const { data: targetData, error: targetErr } = await supabaseAdmin.auth.admin.getUserById(
+      grant.target_user_id,
+    );
+    if (targetErr || !targetData?.user?.email) {
+      return NextResponse.json({ error: "Target user has no email" }, { status: 400 });
+    }
+    const targetEmail = targetData.user.email;
+
+    // Create the intent token first so its id can be embedded in the
+    // magic-link redirect.
+    const ip =
+      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+      req.headers.get("x-real-ip") ??
+      null;
+    const userAgent = req.headers.get("user-agent")?.slice(0, 500) ?? null;
+
+    const { data: session, error: sessionErr } = await supabaseAdmin
+      .from("impersonation_sessions")
+      .insert({
+        grant_id: grant.id,
+        target_user_id: grant.target_user_id,
+        requester_id: callerId,
+        ip,
+        user_agent: userAgent,
+      })
+      .select("id")
+      .single();
+
+    if (sessionErr || !session) {
+      console.error("[admin:impersonation:start] session insert failed", sessionErr);
+      return NextResponse.json({ error: "Could not start session" }, { status: 500 });
+    }
+
+    // The host the admin's browser landed on — used so dev can hit
+    // localhost and prod can hit www.zervo.app without env juggling.
+    const origin = req.headers.get("origin") || `https://${req.headers.get("host")}`;
+    const redirectTo = `${origin}/auth/callback?next=${encodeURIComponent(
+      `/impersonation/begin?session=${session.id}`,
+    )}`;
+
+    const { data: linkData, error: linkErr } =
+      await supabaseAdmin.auth.admin.generateLink({
+        type: "magiclink",
+        email: targetEmail,
+        options: { redirectTo },
+      });
+
+    if (linkErr || !linkData?.properties?.action_link) {
+      console.error("[admin:impersonation:start] generateLink failed", linkErr);
+      // Drop the dangling session row so it doesn't appear in audit as a
+      // mystery never-consumed entry.
+      await supabaseAdmin.from("impersonation_sessions").delete().eq("id", session.id);
+      return NextResponse.json({ error: "Could not generate magic link" }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      session_id: session.id,
+      action_link: linkData.properties.action_link,
+    });
+  },
+);

--- a/apps/finance/src/app/api/admin/impersonation/route.ts
+++ b/apps/finance/src/app/api/admin/impersonation/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAuth } from "../../../../lib/api/withAuth";
+import { isCallerAdmin } from "../../../../lib/api/admin";
+import { supabaseAdmin } from "../../../../lib/supabase/admin";
+import { isOpen, type GrantRow } from "../../../../lib/impersonation/status";
+
+const VALID_DURATIONS = new Set([3_600, 86_400, 604_800]); // 1h, 24h, 7d
+
+/**
+ * Admin requests impersonation access to a target user. The target must
+ * approve in their finance app before the grant becomes usable. We refuse
+ * to create a second open grant for the same (requester, target) pair so
+ * the user's banner doesn't accumulate stacked requests.
+ */
+export const POST = withAuth("admin:impersonation:create", async (req, callerId) => {
+  if (!(await isCallerAdmin(callerId))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as {
+    target_user_id?: string;
+    reason?: string;
+    duration_seconds?: number;
+  };
+
+  const targetUserId = body.target_user_id?.trim();
+  if (!targetUserId) {
+    return NextResponse.json({ error: "target_user_id required" }, { status: 400 });
+  }
+
+  const duration = body.duration_seconds ?? 86_400;
+  if (!VALID_DURATIONS.has(duration)) {
+    return NextResponse.json(
+      { error: "duration_seconds must be 3600, 86400, or 604800" },
+      { status: 400 },
+    );
+  }
+
+  // Confirm the target exists. Without this we'd happily create a grant
+  // pointing at a nonexistent uuid that the FK would only catch on insert
+  // — surface the error early so the admin sees a clean message.
+  const { data: target, error: targetErr } = await supabaseAdmin.auth.admin.getUserById(
+    targetUserId,
+  );
+  if (targetErr || !target?.user) {
+    return NextResponse.json({ error: "Target user not found" }, { status: 404 });
+  }
+
+  // Refuse to stack requests on the same target. If there's already a
+  // pending or active (approved + unexpired) grant, return it instead.
+  const { data: existing } = await supabaseAdmin
+    .from("impersonation_grants")
+    .select("id, status, expires_at, decided_at, duration_seconds, requested_at, reason")
+    .eq("requester_id", callerId)
+    .eq("target_user_id", targetUserId)
+    .in("status", ["pending", "approved"])
+    .order("requested_at", { ascending: false })
+    .limit(1);
+
+  const open = (existing as GrantRow[] | null)?.find((g) => isOpen(g));
+  if (open) {
+    return NextResponse.json({ grant: open, already_open: true });
+  }
+
+  const { data: inserted, error: insertErr } = await supabaseAdmin
+    .from("impersonation_grants")
+    .insert({
+      requester_id: callerId,
+      target_user_id: targetUserId,
+      status: "pending",
+      reason: body.reason?.slice(0, 500) ?? null,
+      duration_seconds: duration,
+    })
+    .select("id, status, expires_at, decided_at, duration_seconds, requested_at, reason")
+    .single();
+
+  if (insertErr || !inserted) {
+    console.error("[admin:impersonation:create] insert failed", insertErr);
+    return NextResponse.json({ error: "Could not create grant" }, { status: 500 });
+  }
+
+  return NextResponse.json({ grant: inserted });
+});
+
+/**
+ * List the caller's grants against a specific target. Used by the admin
+ * UserDrawer to show current state ("pending", "active", or "request").
+ * Caller must be an admin AND the requester on the grants we return —
+ * we never leak grants belonging to other admins.
+ */
+export const GET = withAuth("admin:impersonation:list", async (req: NextRequest, callerId) => {
+  if (!(await isCallerAdmin(callerId))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const target = req.nextUrl.searchParams.get("target");
+  if (!target) {
+    return NextResponse.json({ error: "target query param required" }, { status: 400 });
+  }
+
+  const { data, error } = await supabaseAdmin
+    .from("impersonation_grants")
+    .select("id, status, expires_at, decided_at, duration_seconds, requested_at, reason")
+    .eq("requester_id", callerId)
+    .eq("target_user_id", target)
+    .order("requested_at", { ascending: false })
+    .limit(20);
+
+  if (error) {
+    console.error("[admin:impersonation:list] query failed", error);
+    return NextResponse.json({ error: "Could not load grants" }, { status: 500 });
+  }
+
+  return NextResponse.json({ grants: data ?? [] });
+});

--- a/apps/finance/src/app/api/impersonation/begin/route.ts
+++ b/apps/finance/src/app/api/impersonation/begin/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAuth } from "../../../../lib/api/withAuth";
+import { supabaseAdmin } from "../../../../lib/supabase/admin";
+import {
+  IMPERSONATION_COOKIE_NAME,
+  IMPERSONATION_COOKIE_OPTIONS,
+} from "../../../../lib/impersonation/cookie";
+
+/**
+ * After the magic-link callback exchanges a Supabase session for the target
+ * user, the client is bounced to `/impersonation/begin?session=<id>` which
+ * POSTs here. We validate the session row, mark it consumed, and set the
+ * impersonator cookie so subsequent server reads can flag this browser
+ * tab as "currently impersonating."
+ *
+ * The bearer token must belong to the target user (the magic link just
+ * minted that session) — anyone else is rejected. Without that check a
+ * leaked session_id could be used by anyone who happens to be logged in.
+ */
+export const POST = withAuth("impersonation:begin", async (req: NextRequest, callerId) => {
+  const sessionId = req.nextUrl.searchParams.get("session");
+  if (!sessionId) {
+    return NextResponse.json({ error: "Missing session id" }, { status: 400 });
+  }
+
+  const { data: session, error } = await supabaseAdmin
+    .from("impersonation_sessions")
+    .select("id, target_user_id, consumed_at, started_at, grant_id")
+    .eq("id", sessionId)
+    .single();
+
+  if (error || !session) {
+    return NextResponse.json({ error: "Session not found" }, { status: 404 });
+  }
+  if (session.target_user_id !== callerId) {
+    return NextResponse.json({ error: "Session does not match caller" }, { status: 403 });
+  }
+  if (session.consumed_at) {
+    return NextResponse.json({ error: "Session already consumed" }, { status: 400 });
+  }
+  // Intent tokens are short-lived to limit replay-window if a redirect URL
+  // ends up in browser history or referrer logs. 10 min is plenty for the
+  // magic-link round-trip.
+  const ageMs = Date.now() - new Date(session.started_at).getTime();
+  if (ageMs > 10 * 60 * 1000) {
+    return NextResponse.json({ error: "Session token expired" }, { status: 400 });
+  }
+
+  // Verify the underlying grant is still valid. Without this, a session
+  // started before the target hit "Revoke" could still be consumed.
+  const { data: grant } = await supabaseAdmin
+    .from("impersonation_grants")
+    .select("status, expires_at")
+    .eq("id", session.grant_id)
+    .single();
+  if (
+    !grant ||
+    grant.status !== "approved" ||
+    !grant.expires_at ||
+    new Date(grant.expires_at).getTime() < Date.now()
+  ) {
+    return NextResponse.json({ error: "Grant is no longer active" }, { status: 400 });
+  }
+
+  await supabaseAdmin
+    .from("impersonation_sessions")
+    .update({ consumed_at: new Date().toISOString() })
+    .eq("id", sessionId);
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(IMPERSONATION_COOKIE_NAME, sessionId, IMPERSONATION_COOKIE_OPTIONS);
+  return res;
+});

--- a/apps/finance/src/app/api/impersonation/exit/route.ts
+++ b/apps/finance/src/app/api/impersonation/exit/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAuth } from "../../../../lib/api/withAuth";
+import { supabaseAdmin } from "../../../../lib/supabase/admin";
+import { IMPERSONATION_COOKIE_NAME } from "../../../../lib/impersonation/cookie";
+
+/**
+ * Admin clicks "Exit impersonation" → mark session ended and clear the
+ * cookie. The Supabase session itself is invalidated client-side (signOut)
+ * so the tab can't continue making requests as the target.
+ */
+export const POST = withAuth("impersonation:exit", async (req: NextRequest, callerId) => {
+  const sessionId = req.cookies.get(IMPERSONATION_COOKIE_NAME)?.value;
+
+  if (sessionId) {
+    const { data: session } = await supabaseAdmin
+      .from("impersonation_sessions")
+      .select("id, target_user_id, ended_at")
+      .eq("id", sessionId)
+      .single();
+
+    // Only end the session if it actually belongs to this tab. If the
+    // cookie is stale (different target signed in here later), ignore.
+    if (session && session.target_user_id === callerId && !session.ended_at) {
+      await supabaseAdmin
+        .from("impersonation_sessions")
+        .update({ ended_at: new Date().toISOString() })
+        .eq("id", sessionId);
+    }
+  }
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(IMPERSONATION_COOKIE_NAME, "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+  });
+  return res;
+});

--- a/apps/finance/src/app/api/impersonation/me/route.ts
+++ b/apps/finance/src/app/api/impersonation/me/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { withAuth } from "../../../../lib/api/withAuth";
+import { supabaseAdmin } from "../../../../lib/supabase/admin";
+import { IMPERSONATION_COOKIE_NAME } from "../../../../lib/impersonation/cookie";
+
+/**
+ * Returns the current impersonation context (if any) for the requesting
+ * tab. Validates that:
+ *   - the cookie session_id maps to an unended, consumed session
+ *   - target_user_id matches the bearer token's user (otherwise the cookie
+ *     is stale from a prior impersonation and we ignore it)
+ *   - the underlying grant is still approved + unexpired
+ *
+ * Banner mounts call this on every page load to decide whether to render
+ * the red "you're impersonating" bar.
+ */
+export const GET = withAuth("impersonation:me", async (req: NextRequest, callerId) => {
+  const sessionId = req.cookies.get(IMPERSONATION_COOKIE_NAME)?.value;
+  if (!sessionId) {
+    return NextResponse.json({ impersonating: false });
+  }
+
+  const { data: session } = await supabaseAdmin
+    .from("impersonation_sessions")
+    .select("id, target_user_id, requester_id, ended_at, consumed_at, grant_id, started_at")
+    .eq("id", sessionId)
+    .single();
+
+  if (!session || session.target_user_id !== callerId) {
+    return NextResponse.json({ impersonating: false });
+  }
+  if (!session.consumed_at || session.ended_at) {
+    return NextResponse.json({ impersonating: false });
+  }
+
+  const { data: grant } = await supabaseAdmin
+    .from("impersonation_grants")
+    .select("status, expires_at")
+    .eq("id", session.grant_id)
+    .single();
+  if (
+    !grant ||
+    grant.status !== "approved" ||
+    !grant.expires_at ||
+    new Date(grant.expires_at).getTime() < Date.now()
+  ) {
+    return NextResponse.json({ impersonating: false });
+  }
+
+  const { data: requester } = await supabaseAdmin.auth.admin.getUserById(session.requester_id);
+
+  return NextResponse.json({
+    impersonating: true,
+    session_id: session.id,
+    requester_email: requester?.user?.email ?? null,
+    expires_at: grant.expires_at,
+    started_at: session.started_at,
+  });
+});

--- a/apps/finance/src/app/api/plaid/disconnect-account/route.ts
+++ b/apps/finance/src/app/api/plaid/disconnect-account/route.ts
@@ -14,12 +14,16 @@ import {
   disconnectAccount,
   DisconnectError,
 } from '../../../../lib/plaid/disconnectAccount';
+import { blockedByImpersonation } from '../../../../lib/impersonation/guard';
 
 interface RequestBody {
   accountId?: string;
 }
 
 export const POST = withAuth('plaid:disconnect-account', async (request, userId) => {
+  const blocked = await blockedByImpersonation(request);
+  if (blocked) return blocked;
+
   const { accountId } = (await request.json()) as RequestBody;
 
   if (!accountId) {

--- a/apps/finance/src/app/api/plaid/disconnect/route.ts
+++ b/apps/finance/src/app/api/plaid/disconnect/route.ts
@@ -2,12 +2,16 @@ import { removeItem } from '../../../../lib/plaid/client';
 import { decryptPlaidToken } from '../../../../lib/crypto/plaidTokens';
 import { supabaseAdmin } from '../../../../lib/supabase/admin';
 import { withAuth } from '../../../../lib/api/withAuth';
+import { blockedByImpersonation } from '../../../../lib/impersonation/guard';
 
 interface RequestBody {
   plaidItemId?: string;
 }
 
 export const POST = withAuth('plaid:disconnect', async (request, userId) => {
+  const blocked = await blockedByImpersonation(request);
+  if (blocked) return blocked;
+
   const { plaidItemId } = (await request.json()) as RequestBody;
   console.log('Disconnect request for plaid item:', plaidItemId, 'user:', userId);
   if (!plaidItemId) {

--- a/apps/finance/src/app/api/stripe/checkout/route.ts
+++ b/apps/finance/src/app/api/stripe/checkout/route.ts
@@ -1,6 +1,7 @@
 import { requireStripe } from '../../../../lib/stripe/client';
 import { supabaseAdmin } from '../../../../lib/supabase/admin';
 import { withAuth } from '../../../../lib/api/withAuth';
+import { blockedByImpersonation } from '../../../../lib/impersonation/guard';
 
 /**
  * POST /api/stripe/checkout
@@ -12,7 +13,10 @@ import { withAuth } from '../../../../lib/api/withAuth';
  * - Stores the stripe_customer_id on the user_profiles row so we can
  *   match webhook events back to the right user.
  */
-export const POST = withAuth('stripe:checkout', async (_request, userId) => {
+export const POST = withAuth('stripe:checkout', async (request, userId) => {
+    const blocked = await blockedByImpersonation(request);
+    if (blocked) return blocked;
+
     const stripe = requireStripe();
 
     const priceId = process.env.STRIPE_PRO_PRICE_ID;

--- a/apps/finance/src/app/api/stripe/portal/route.ts
+++ b/apps/finance/src/app/api/stripe/portal/route.ts
@@ -1,6 +1,7 @@
 import { requireStripe } from '../../../../lib/stripe/client';
 import { supabaseAdmin } from '../../../../lib/supabase/admin';
 import { withAuth } from '../../../../lib/api/withAuth';
+import { blockedByImpersonation } from '../../../../lib/impersonation/guard';
 
 /**
  * POST /api/stripe/portal
@@ -12,7 +13,10 @@ import { withAuth } from '../../../../lib/api/withAuth';
  * Requires the user to have a stripe_customer_id already set (i.e., they
  * went through Checkout at least once).
  */
-export const POST = withAuth('stripe:portal', async (_request, userId) => {
+export const POST = withAuth('stripe:portal', async (request, userId) => {
+    const blocked = await blockedByImpersonation(request);
+    if (blocked) return blocked;
+
     const stripe = requireStripe();
 
     const { data: profile, error: profileError } = await supabaseAdmin!

--- a/apps/finance/src/app/impersonation/begin/page.tsx
+++ b/apps/finance/src/app/impersonation/begin/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { authFetch } from "../../../lib/api/fetch";
+
+function BeginHandler() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const attempted = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    attempted.current = true;
+
+    const sessionId = searchParams.get("session");
+    if (!sessionId) {
+      router.replace("/dashboard");
+      return;
+    }
+
+    authFetch(`/api/impersonation/begin?session=${encodeURIComponent(sessionId)}`, {
+      method: "POST",
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body?.error || `Begin failed (${res.status})`);
+        }
+        router.replace("/dashboard");
+      })
+      .catch((e) => {
+        setError(e?.message || "Could not start session");
+      });
+  }, [router, searchParams]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-zinc-50 text-zinc-900">
+      <div className="text-center">
+        {error ? (
+          <>
+            <div className="text-sm font-medium">Could not enter session</div>
+            <div className="text-xs text-zinc-500 mt-1">{error}</div>
+          </>
+        ) : (
+          <div className="text-sm text-zinc-500">Entering session…</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function BeginPage() {
+  return (
+    <Suspense>
+      <BeginHandler />
+    </Suspense>
+  );
+}

--- a/apps/finance/src/components/ImpersonationBanner.tsx
+++ b/apps/finance/src/components/ImpersonationBanner.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FiAlertOctagon } from "react-icons/fi";
+import { authFetch } from "../lib/api/fetch";
+import { supabase } from "../lib/supabase/client";
+
+type Context = {
+  impersonating: boolean;
+  requester_email?: string | null;
+  expires_at?: string | null;
+  started_at?: string | null;
+  session_id?: string;
+};
+
+function formatExpiresIn(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return "expired";
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 60) return `${mins}m left`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h left`;
+  const days = Math.floor(hours / 24);
+  return `${days}d left`;
+}
+
+/**
+ * Persistent red bar shown when the current tab is impersonating another
+ * user. Click "Exit" to end the session — clears the impersonator cookie,
+ * marks the session ended, signs out of Supabase (kills the minted target
+ * session for THIS browser only; the target's other devices keep working),
+ * and routes back to the admin app.
+ */
+export default function ImpersonationBanner() {
+  const [ctx, setCtx] = useState<Context>({ impersonating: false });
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await authFetch("/api/impersonation/me");
+        if (!res.ok) return;
+        const body = await res.json();
+        if (cancelled) return;
+        setCtx(body as Context);
+      } catch {
+        // Silent — banner just stays hidden.
+      }
+    }
+    load();
+    const interval = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (!ctx.impersonating) return null;
+
+  async function exit() {
+    setExiting(true);
+    try {
+      await authFetch("/api/impersonation/exit", { method: "POST" });
+      try {
+        await supabase.auth.signOut();
+      } catch {
+        // Best-effort — even if signOut fails, the cookie is cleared and
+        // the next /me call will return false.
+      }
+      // Send the admin back to the admin app since that's where they
+      // started. window.location to force a hard navigation off this
+      // app's localStorage state.
+      const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || "https://admin.zervo.app";
+      window.location.href = adminUrl;
+    } finally {
+      setExiting(false);
+    }
+  }
+
+  return (
+    <div className="bg-[var(--color-danger)]/95 text-white px-4 py-2 flex items-center justify-center gap-3 text-sm border-b border-black/10">
+      <FiAlertOctagon className="h-4 w-4 flex-shrink-0" />
+      <span>
+        Impersonating as this user
+        {ctx.requester_email ? (
+          <>
+            {" "}— signed in via <strong className="font-medium">{ctx.requester_email}</strong>
+          </>
+        ) : null}
+        {ctx.expires_at ? <> · {formatExpiresIn(ctx.expires_at)}</> : null}
+      </span>
+      <button
+        onClick={exit}
+        disabled={exiting}
+        className="ml-2 text-xs font-medium px-2.5 py-1 rounded bg-white/15 hover:bg-white/25 disabled:opacity-50"
+      >
+        {exiting ? "Exiting…" : "Exit impersonation"}
+      </button>
+    </div>
+  );
+}

--- a/apps/finance/src/components/ImpersonationRequestBanner.tsx
+++ b/apps/finance/src/components/ImpersonationRequestBanner.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FiShield, FiX } from "react-icons/fi";
+import Link from "next/link";
+import { authFetch } from "../lib/api/fetch";
+
+type Grant = {
+  id: string;
+  status: string;
+  expires_at: string | null;
+  decided_at: string | null;
+  duration_seconds: number;
+  requested_at: string;
+  reason: string | null;
+  requester_email: string | null;
+};
+
+function formatDuration(seconds: number): string {
+  if (seconds >= 86_400) return `${seconds / 86_400}d`;
+  if (seconds >= 3_600) return `${Math.round(seconds / 3_600)}h`;
+  return `${Math.round(seconds / 60)}m`;
+}
+
+/**
+ * Top-of-app banner shown when an admin has requested impersonation
+ * access. Inline approve/deny/dismiss; deeper management lives at
+ * /settings/support-access. We only show the OLDEST pending request to
+ * keep the bar single-line — additional requests appear as the user
+ * acts on each.
+ */
+export default function ImpersonationRequestBanner() {
+  const [grants, setGrants] = useState<Grant[]>([]);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await authFetch("/api/account/impersonation");
+        if (!res.ok) return;
+        const body = await res.json();
+        if (cancelled) return;
+        setGrants((body?.grants as Grant[]) ?? []);
+      } catch {
+        // Silent failure — banner just won't show. Not load-bearing UX.
+      }
+    }
+    load();
+    const interval = setInterval(load, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const pending = grants
+    .filter((g) => g.status === "pending" && !hidden.has(g.id))
+    .sort((a, b) => new Date(a.requested_at).getTime() - new Date(b.requested_at).getTime());
+  const target = pending[0];
+  if (!target) return null;
+
+  async function decide(id: string, action: "approve" | "deny") {
+    setBusy(id);
+    try {
+      const res = await authFetch(`/api/account/impersonation/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      if (res.ok) {
+        const body = await res.json();
+        const updated = body?.grant as Grant | undefined;
+        if (updated) {
+          setGrants((prev) =>
+            prev.map((g) => (g.id === updated.id ? { ...g, ...updated } : g)),
+          );
+        }
+      }
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="bg-[var(--color-accent)]/10 border-b border-[var(--color-accent)]/20 px-4 py-2.5 flex items-center justify-center gap-3 text-sm flex-wrap">
+      <FiShield className="h-4 w-4 text-[var(--color-accent)] flex-shrink-0" />
+      <span className="text-[var(--color-fg)]">
+        <strong className="font-medium">
+          {target.requester_email ?? "An admin"}
+        </strong>{" "}
+        is requesting access to your account
+        {target.reason ? <> — “{target.reason}”</> : ""}.
+      </span>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <button
+          onClick={() => decide(target.id, "approve")}
+          disabled={busy === target.id}
+          className="text-xs font-medium px-2.5 py-1 rounded bg-[var(--color-accent)] text-[var(--color-on-accent)] hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
+        >
+          {busy === target.id ? "…" : `Approve ${formatDuration(target.duration_seconds)}`}
+        </button>
+        <button
+          onClick={() => decide(target.id, "deny")}
+          disabled={busy === target.id}
+          className="text-xs font-medium text-[var(--color-fg)] hover:underline disabled:opacity-50"
+        >
+          Deny
+        </button>
+        <Link
+          href="/settings/support-access"
+          className="text-xs text-[var(--color-muted)] hover:text-[var(--color-fg)]"
+        >
+          Details
+        </Link>
+        <button
+          onClick={() => setHidden((s) => new Set(s).add(target.id))}
+          className="p-0.5 rounded text-[var(--color-muted)] hover:text-[var(--color-fg)] transition-colors"
+          aria-label="Dismiss"
+        >
+          <FiX className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/finance/src/components/layout/AppShell.tsx
+++ b/apps/finance/src/components/layout/AppShell.tsx
@@ -18,6 +18,7 @@ import { supabase } from "../../lib/supabase/client";
 import PlaidOAuthHandler from "../PlaidOAuthHandler";
 import PaymentFailureBanner from "../PaymentFailureBanner";
 import ImpersonationRequestBanner from "../ImpersonationRequestBanner";
+import ImpersonationBanner from "../ImpersonationBanner";
 import { BrandMark, ConfirmOverlay } from "@zervo/ui";
 
 function SetupShell({ children }: { children: React.ReactNode }) {
@@ -236,6 +237,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       />
       <ProfileBar />
       <div className="min-h-screen flex flex-col transition-all duration-300 ease-in-out md:ml-20 xl:ml-60 relative">
+        <ImpersonationBanner />
         <PaymentFailureBanner />
         <ImpersonationRequestBanner />
         {/* Main content rendered as a "giant card" — bg-content surface

--- a/apps/finance/src/components/layout/AppShell.tsx
+++ b/apps/finance/src/components/layout/AppShell.tsx
@@ -17,6 +17,7 @@ import { useUser } from "../providers/UserProvider";
 import { supabase } from "../../lib/supabase/client";
 import PlaidOAuthHandler from "../PlaidOAuthHandler";
 import PaymentFailureBanner from "../PaymentFailureBanner";
+import ImpersonationRequestBanner from "../ImpersonationRequestBanner";
 import { BrandMark, ConfirmOverlay } from "@zervo/ui";
 
 function SetupShell({ children }: { children: React.ReactNode }) {
@@ -236,6 +237,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       <ProfileBar />
       <div className="min-h-screen flex flex-col transition-all duration-300 ease-in-out md:ml-20 xl:ml-60 relative">
         <PaymentFailureBanner />
+        <ImpersonationRequestBanner />
         {/* Main content rendered as a "giant card" — bg-content surface
             sitting inside the shell so the sidebar reads as navigation
             chrome on a different layer. The AppTopbar lives INSIDE the

--- a/apps/finance/src/lib/impersonation/cookie.ts
+++ b/apps/finance/src/lib/impersonation/cookie.ts
@@ -1,0 +1,15 @@
+/**
+ * Constants and helpers for the impersonation cookie. The cookie is
+ * httpOnly so client JS can't read or forge it — banner state comes
+ * from /api/impersonation/me, which validates the cookie server-side
+ * against impersonation_sessions before returning context.
+ */
+
+export const IMPERSONATION_COOKIE_NAME = "zervo_impersonator_session";
+
+export const IMPERSONATION_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+};

--- a/apps/finance/src/lib/impersonation/guard.ts
+++ b/apps/finance/src/lib/impersonation/guard.ts
@@ -1,0 +1,42 @@
+import type { NextRequest } from "next/server";
+import { supabaseAdmin } from "../supabase/admin";
+import { IMPERSONATION_COOKIE_NAME } from "./cookie";
+
+/**
+ * Returns a 403 Response if the request is being made inside an active
+ * impersonation session, otherwise null. Use as a one-line guard at the
+ * top of routes whose blast radius is too large to allow during support
+ * sessions: account deletion, Plaid disconnect, Stripe subscription
+ * changes, etc.
+ *
+ * Reading-only or low-blast actions (categorize a transaction, edit a
+ * budget) are NOT guarded — being able to see and edit data is the whole
+ * point of impersonation.
+ *
+ *     export const POST = withAuth("foo", async (req, userId) => {
+ *       const blocked = await blockedByImpersonation(req);
+ *       if (blocked) return blocked;
+ *       ...
+ *     });
+ */
+export async function blockedByImpersonation(request: NextRequest): Promise<Response | null> {
+  const sessionId = request.cookies.get(IMPERSONATION_COOKIE_NAME)?.value;
+  if (!sessionId) return null;
+
+  const { data: session } = await supabaseAdmin
+    .from("impersonation_sessions")
+    .select("id, ended_at, consumed_at")
+    .eq("id", sessionId)
+    .single();
+
+  // Stale cookie (session ended or never consumed) — let the request
+  // through. /me would return impersonating: false in this state too.
+  if (!session || !session.consumed_at || session.ended_at) return null;
+
+  return Response.json(
+    {
+      error: "This action is blocked while impersonating. Exit impersonation to perform it.",
+    },
+    { status: 403 },
+  );
+}

--- a/apps/finance/src/lib/impersonation/status.ts
+++ b/apps/finance/src/lib/impersonation/status.ts
@@ -1,0 +1,35 @@
+/**
+ * Helpers for reasoning about the lifecycle state of an impersonation grant.
+ * The DB stores raw status values; the app wants to know "is this grant
+ * currently usable" (approved + not expired) vs. "actionable" (pending or
+ * approved-and-not-expired) vs. "settled" (denied/revoked/expired).
+ */
+
+export type GrantStatus =
+  | "pending"
+  | "approved"
+  | "denied"
+  | "revoked"
+  | "expired";
+
+export type GrantRow = {
+  id: string;
+  status: string;
+  expires_at: string | null;
+  decided_at: string | null;
+  duration_seconds: number;
+  requested_at: string;
+  reason: string | null;
+};
+
+export function isActive(grant: Pick<GrantRow, "status" | "expires_at">): boolean {
+  if (grant.status !== "approved") return false;
+  if (!grant.expires_at) return false;
+  return new Date(grant.expires_at).getTime() > Date.now();
+}
+
+export function isOpen(grant: Pick<GrantRow, "status" | "expires_at">): boolean {
+  if (grant.status === "pending") return true;
+  if (isActive(grant)) return true;
+  return false;
+}

--- a/apps/finance/supabase/migrations/20260430050640_create_impersonation_tables.sql
+++ b/apps/finance/supabase/migrations/20260430050640_create_impersonation_tables.sql
@@ -1,0 +1,76 @@
+-- Impersonation: lets an admin (requester) ask a user (target) for
+-- temporary "log in as me" access. The target approves/denies in their
+-- finance app; on approval the admin gets a one-time link that mints a
+-- Supabase session for the target with a separate `impersonator` cookie
+-- gating destructive actions.
+--
+-- impersonation_grants: one row per request lifecycle (pending →
+-- approved/denied → revoked/expired).
+-- impersonation_sessions: one row per "enter session" click — the audit
+-- trail visible to both target and requester.
+
+create table public.impersonation_grants (
+  id uuid primary key default gen_random_uuid(),
+  target_user_id uuid not null references auth.users(id) on delete cascade,
+  requester_id uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'pending' check (status in (
+    'pending', 'approved', 'denied', 'revoked', 'expired'
+  )),
+  reason text,
+  duration_seconds int not null default 86400,
+  requested_at timestamptz not null default now(),
+  decided_at timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index impersonation_grants_target_idx
+  on public.impersonation_grants (target_user_id, status, requested_at desc);
+create index impersonation_grants_requester_idx
+  on public.impersonation_grants (requester_id, status, requested_at desc);
+
+create table public.impersonation_sessions (
+  id uuid primary key default gen_random_uuid(),
+  grant_id uuid not null references public.impersonation_grants(id) on delete cascade,
+  target_user_id uuid not null references auth.users(id) on delete cascade,
+  requester_id uuid not null references auth.users(id) on delete cascade,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz,
+  ip text,
+  user_agent text,
+  created_at timestamptz not null default now()
+);
+
+create index impersonation_sessions_grant_idx
+  on public.impersonation_sessions (grant_id, started_at desc);
+create index impersonation_sessions_target_idx
+  on public.impersonation_sessions (target_user_id, started_at desc);
+
+alter table public.impersonation_grants enable row level security;
+alter table public.impersonation_sessions enable row level security;
+
+-- Target can view + update (approve/deny/revoke) their own grants.
+create policy "target_can_view_own_grants"
+  on public.impersonation_grants for select
+  using (auth.uid() = target_user_id);
+
+create policy "target_can_update_own_grants"
+  on public.impersonation_grants for update
+  using (auth.uid() = target_user_id)
+  with check (auth.uid() = target_user_id);
+
+-- Requester can view their outgoing grants. They cannot directly write —
+-- inserts/state changes go through the admin proxy → finance API → service
+-- role, so server code controls the lifecycle.
+create policy "requester_can_view_own_grants"
+  on public.impersonation_grants for select
+  using (auth.uid() = requester_id);
+
+-- Sessions are read-only audit. Target + requester can see their own.
+create policy "target_can_view_own_sessions"
+  on public.impersonation_sessions for select
+  using (auth.uid() = target_user_id);
+
+create policy "requester_can_view_own_sessions"
+  on public.impersonation_sessions for select
+  using (auth.uid() = requester_id);

--- a/apps/finance/supabase/migrations/20260430052610_add_consumed_at_to_impersonation_sessions.sql
+++ b/apps/finance/supabase/migrations/20260430052610_add_consumed_at_to_impersonation_sessions.sql
@@ -1,0 +1,8 @@
+-- Each `impersonation_sessions` row is created when the admin clicks
+-- "Enter session" but before the magic link is actually consumed by
+-- their browser. consumed_at marks the moment the magic-link redirect
+-- hits our /api/impersonation/begin endpoint and the session becomes
+-- usable. A row with consumed_at = null is a single-use intent token;
+-- after the first hit it can't be replayed.
+alter table public.impersonation_sessions
+  add column consumed_at timestamptz;

--- a/packages/supabase/src/database.ts
+++ b/packages/supabase/src/database.ts
@@ -464,6 +464,7 @@ export type Database = {
       }
       impersonation_sessions: {
         Row: {
+          consumed_at: string | null
           created_at: string
           ended_at: string | null
           grant_id: string
@@ -475,6 +476,7 @@ export type Database = {
           user_agent: string | null
         }
         Insert: {
+          consumed_at?: string | null
           created_at?: string
           ended_at?: string | null
           grant_id: string
@@ -486,6 +488,7 @@ export type Database = {
           user_agent?: string | null
         }
         Update: {
+          consumed_at?: string | null
           created_at?: string
           ended_at?: string | null
           grant_id?: string

--- a/packages/supabase/src/database.ts
+++ b/packages/supabase/src/database.ts
@@ -423,6 +423,89 @@ export type Database = {
         }
         Relationships: []
       }
+      impersonation_grants: {
+        Row: {
+          created_at: string
+          decided_at: string | null
+          duration_seconds: number
+          expires_at: string | null
+          id: string
+          reason: string | null
+          requested_at: string
+          requester_id: string
+          status: string
+          target_user_id: string
+        }
+        Insert: {
+          created_at?: string
+          decided_at?: string | null
+          duration_seconds?: number
+          expires_at?: string | null
+          id?: string
+          reason?: string | null
+          requested_at?: string
+          requester_id: string
+          status?: string
+          target_user_id: string
+        }
+        Update: {
+          created_at?: string
+          decided_at?: string | null
+          duration_seconds?: number
+          expires_at?: string | null
+          id?: string
+          reason?: string | null
+          requested_at?: string
+          requester_id?: string
+          status?: string
+          target_user_id?: string
+        }
+        Relationships: []
+      }
+      impersonation_sessions: {
+        Row: {
+          created_at: string
+          ended_at: string | null
+          grant_id: string
+          id: string
+          ip: string | null
+          requester_id: string
+          started_at: string
+          target_user_id: string
+          user_agent: string | null
+        }
+        Insert: {
+          created_at?: string
+          ended_at?: string | null
+          grant_id: string
+          id?: string
+          ip?: string | null
+          requester_id: string
+          started_at?: string
+          target_user_id: string
+          user_agent?: string | null
+        }
+        Update: {
+          created_at?: string
+          ended_at?: string | null
+          grant_id?: string
+          id?: string
+          ip?: string | null
+          requester_id?: string
+          started_at?: string
+          target_user_id?: string
+          user_agent?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "impersonation_sessions_grant_id_fkey"
+            columns: ["grant_id"]
+            isOneToOne: false
+            referencedRelation: "impersonation_grants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       institutions: {
         Row: {
           created_at: string


### PR DESCRIPTION
## Summary

- **Admin overview redesign** — replace "Recent signups" with "Recently online" (5 users by `last_active_at` with green/amber presence dots), drop the redundant Quick Actions block, and reorder stats so the "online now" count surfaces.
- **Impersonation feature** — admin requests access from the user drawer; user approves from a banner in their finance app; admin opens a new tab via Supabase magic link minted on the target's session; persistent red bar shows during the session with one-click exit.
- **Destructive action guard** — `blockedByImpersonation()` returns 403 from account/delete, plaid/disconnect(-account), and stripe/checkout|portal when an active impersonation cookie is present.

## Migrations applied to prod

- `20260430050640_create_impersonation_tables` — grants + sessions tables with RLS
- `20260430052610_add_consumed_at_to_impersonation_sessions` — single-use intent tokens

## Test plan

- [ ] In admin app, open a user's drawer → "Request access" with a 24h duration → check finance app shows the banner with approve/deny
- [ ] Approve from finance — admin drawer flips to "Active — expires in 24h"
- [ ] Click "Enter session" — new tab opens, lands on /dashboard with red impersonation bar
- [ ] Try `/api/account/delete` from impersonated tab — should 403 with the impersonation message
- [ ] Click "Exit impersonation" — bar disappears, signOut fires, redirect to admin.zervo.app
- [ ] Revoke from /settings/support-access while a session is open — within 60s the banner disappears (next /me call returns false)
- [ ] Re-using the consume URL after first hit → 400 "already consumed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)