### PR TITLE
feat(impersonation): polish drawer UI + indefinite duration

### DIFF
--- a/apps/admin/src/app/(admin)/users/UserDrawer.tsx
+++ b/apps/admin/src/app/(admin)/users/UserDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import clsx from "clsx";
 import { Button, ConfirmOverlay, Drawer } from "@zervo/ui";
 import { billableLinesForItem, formatUsd } from "@/lib/plaidPricing";
 import {
@@ -21,8 +22,20 @@ type Grant = {
   reason: string | null;
 };
 
+// duration_seconds === 0 means indefinite (no expires_at, lasts until
+// the target revokes). All other values are a TTL applied at approve time.
+const DURATION_OPTIONS: { value: number; label: string }[] = [
+  { value: 3_600, label: "1h" },
+  { value: 86_400, label: "1 day" },
+  { value: 604_800, label: "1 week" },
+  { value: 0, label: "Until revoked" },
+];
+
 function isActive(g: Grant): boolean {
-  return g.status === "approved" && !!g.expires_at && new Date(g.expires_at).getTime() > Date.now();
+  if (g.status !== "approved") return false;
+  // null expires_at = indefinite grant (target hasn't revoked).
+  if (!g.expires_at) return true;
+  return new Date(g.expires_at).getTime() > Date.now();
 }
 
 function isOpen(g: Grant): boolean {
@@ -30,7 +43,7 @@ function isOpen(g: Grant): boolean {
 }
 
 function formatExpiresIn(iso: string | null): string {
-  if (!iso) return "—";
+  if (!iso) return "until revoked";
   const ms = new Date(iso).getTime() - Date.now();
   if (ms <= 0) return "expired";
   const mins = Math.floor(ms / 60_000);
@@ -39,6 +52,13 @@ function formatExpiresIn(iso: string | null): string {
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
   return `${days}d`;
+}
+
+function formatRequestedDuration(seconds: number): string {
+  if (seconds === 0) return "until revoked";
+  if (seconds >= 86_400) return `${seconds / 86_400}d`;
+  if (seconds >= 3_600) return `${Math.round(seconds / 3_600)}h`;
+  return `${Math.round(seconds / 60)}m`;
 }
 
 type Props = {
@@ -310,7 +330,7 @@ export default function UserDrawer({
                   </Button>
                 ) : (
                   <Button
-                    variant="secondary"
+                    variant="primary"
                     size="sm"
                     onClick={() => updateSubscription("grant_pro")}
                     disabled={subBusy}
@@ -419,7 +439,7 @@ export default function UserDrawer({
                       </div>
                       <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
                         Requested {formatRelative(openGrant.requested_at)} ·{" "}
-                        {Math.round(openGrant.duration_seconds / 3600)}h grant
+                        {formatRequestedDuration(openGrant.duration_seconds)} grant
                       </div>
                     </div>
                     <Button
@@ -435,7 +455,10 @@ export default function UserDrawer({
                   <div className="flex items-center justify-between gap-4">
                     <div>
                       <div className="text-sm text-[var(--color-success)] font-medium">
-                        Active — expires in {formatExpiresIn(openGrant.expires_at)}
+                        Active —{" "}
+                        {openGrant.expires_at
+                          ? `expires in ${formatExpiresIn(openGrant.expires_at)}`
+                          : "until revoked"}
                       </div>
                       <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
                         Approved {formatRelative(openGrant.decided_at)}
@@ -443,7 +466,7 @@ export default function UserDrawer({
                     </div>
                     <div className="flex items-center gap-2">
                       <Button
-                        variant="secondary"
+                        variant="primary"
                         size="sm"
                         onClick={() => enterSession(openGrant.id)}
                         disabled={grantBusy}
@@ -461,27 +484,30 @@ export default function UserDrawer({
                     </div>
                   </div>
                 ) : (
-                  <div className="space-y-3">
+                  <div className="space-y-4">
                     {lastGrant && (
                       <div className="text-[11px] text-[var(--color-muted)]">
                         Last request: {lastGrant.status} ·{" "}
                         {formatRelative(lastGrant.decided_at ?? lastGrant.requested_at)}
                       </div>
                     )}
-                    <div className="flex items-center gap-3 flex-wrap">
-                      <label className="text-[11px] text-[var(--color-muted)]/70 uppercase tracking-[0.08em]">
-                        Duration
-                      </label>
-                      <select
-                        value={duration}
-                        onChange={(e) => setDuration(Number(e.target.value))}
-                        className="bg-[var(--color-input-bg)] text-[var(--color-input-fg)] text-xs rounded px-2 py-1 outline-none"
-                        disabled={grantBusy}
-                      >
-                        <option value={3_600}>1 hour</option>
-                        <option value={86_400}>24 hours</option>
-                        <option value={604_800}>7 days</option>
-                      </select>
+                    <div className="flex flex-wrap gap-1.5">
+                      {DURATION_OPTIONS.map((opt) => (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          onClick={() => setDuration(opt.value)}
+                          disabled={grantBusy}
+                          className={clsx(
+                            "h-7 px-3 rounded-full text-xs transition-colors disabled:opacity-50",
+                            duration === opt.value
+                              ? "bg-[var(--color-fg)] text-[var(--color-bg)]"
+                              : "bg-[var(--color-surface-alt)] text-[var(--color-muted)] hover:text-[var(--color-fg)]",
+                          )}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
                     </div>
                     <input
                       type="text"
@@ -490,10 +516,10 @@ export default function UserDrawer({
                       placeholder="Reason (optional, shown to user)"
                       maxLength={500}
                       disabled={grantBusy}
-                      className="w-full bg-[var(--color-input-bg)] text-[var(--color-input-fg)] text-xs rounded px-2 py-1.5 outline-none placeholder:text-[var(--color-input-placeholder)]"
+                      className="w-full bg-[var(--color-surface-alt)] text-[var(--color-fg)] text-xs rounded-md px-3 py-2 outline-none placeholder:text-[var(--color-muted)]/70 focus:ring-1 focus:ring-[var(--color-fg)]/20 transition-shadow"
                     />
                     <Button
-                      variant="secondary"
+                      variant="primary"
                       size="sm"
                       onClick={requestImpersonation}
                       disabled={grantBusy}

--- a/apps/finance/src/app/(main)/settings/support-access/page.tsx
+++ b/apps/finance/src/app/(main)/settings/support-access/page.tsx
@@ -34,7 +34,10 @@ function formatRelative(iso: string | null): string {
 }
 
 function isActive(g: Grant): boolean {
-  return g.status === "approved" && !!g.expires_at && new Date(g.expires_at).getTime() > Date.now();
+  if (g.status !== "approved") return false;
+  // null expires_at = indefinite grant.
+  if (!g.expires_at) return true;
+  return new Date(g.expires_at).getTime() > Date.now();
 }
 
 const STATUS_COPY: Record<string, string> = {
@@ -161,7 +164,14 @@ export default function SupportAccessPage() {
                             {formatRelative(g.decided_at)}
                           </>
                         )}
-                        {active && g.expires_at && <> · expires {formatRelative(g.expires_at)}</>}
+                        {active && (
+                          <>
+                            {" · "}
+                            {g.expires_at
+                              ? `expires ${formatRelative(g.expires_at)}`
+                              : "until revoked"}
+                          </>
+                        )}
                       </div>
                     </div>
                     {open && (

--- a/apps/finance/src/app/api/account/impersonation/[id]/route.ts
+++ b/apps/finance/src/app/api/account/impersonation/[id]/route.ts
@@ -48,13 +48,19 @@ export const PATCH = withAuth<{ id: string }>(
         );
       }
       const now = new Date();
-      const expires = new Date(now.getTime() + grant.duration_seconds * 1000);
+      // duration_seconds === 0 means indefinite — leave expires_at null so
+      // the grant runs until revoked. Every guard treats null as "still
+      // valid" provided status is approved.
+      const expires =
+        grant.duration_seconds > 0
+          ? new Date(now.getTime() + grant.duration_seconds * 1000).toISOString()
+          : null;
       const { data: updated, error } = await supabaseAdmin
         .from("impersonation_grants")
         .update({
           status: "approved",
           decided_at: now.toISOString(),
-          expires_at: expires.toISOString(),
+          expires_at: expires,
         })
         .eq("id", grantId)
         .select(

--- a/apps/finance/src/app/api/admin/impersonation/[id]/start/route.ts
+++ b/apps/finance/src/app/api/admin/impersonation/[id]/start/route.ts
@@ -42,7 +42,9 @@ export const POST = withAuth<{ id: string }>(
     if (grant.status !== "approved") {
       return NextResponse.json({ error: `Grant is ${grant.status}` }, { status: 400 });
     }
-    if (!grant.expires_at || new Date(grant.expires_at).getTime() < Date.now()) {
+    // null expires_at = indefinite grant; only block if the grant has a
+    // concrete expiry that's already passed.
+    if (grant.expires_at && new Date(grant.expires_at).getTime() < Date.now()) {
       return NextResponse.json({ error: "Grant has expired" }, { status: 400 });
     }
 

--- a/apps/finance/src/app/api/admin/impersonation/route.ts
+++ b/apps/finance/src/app/api/admin/impersonation/route.ts
@@ -4,7 +4,8 @@ import { isCallerAdmin } from "../../../../lib/api/admin";
 import { supabaseAdmin } from "../../../../lib/supabase/admin";
 import { isOpen, type GrantRow } from "../../../../lib/impersonation/status";
 
-const VALID_DURATIONS = new Set([3_600, 86_400, 604_800]); // 1h, 24h, 7d
+// 0 = indefinite (no expires_at, lasts until target revokes).
+const VALID_DURATIONS = new Set([0, 3_600, 86_400, 604_800]);
 
 /**
  * Admin requests impersonation access to a target user. The target must
@@ -31,7 +32,7 @@ export const POST = withAuth("admin:impersonation:create", async (req, callerId)
   const duration = body.duration_seconds ?? 86_400;
   if (!VALID_DURATIONS.has(duration)) {
     return NextResponse.json(
-      { error: "duration_seconds must be 3600, 86400, or 604800" },
+      { error: "duration_seconds must be 0, 3600, 86400, or 604800" },
       { status: 400 },
     );
   }

--- a/apps/finance/src/app/api/impersonation/begin/route.ts
+++ b/apps/finance/src/app/api/impersonation/begin/route.ts
@@ -53,11 +53,11 @@ export const POST = withAuth("impersonation:begin", async (req: NextRequest, cal
     .select("status, expires_at")
     .eq("id", session.grant_id)
     .single();
+  // null expires_at = indefinite, still active.
   if (
     !grant ||
     grant.status !== "approved" ||
-    !grant.expires_at ||
-    new Date(grant.expires_at).getTime() < Date.now()
+    (grant.expires_at && new Date(grant.expires_at).getTime() < Date.now())
   ) {
     return NextResponse.json({ error: "Grant is no longer active" }, { status: 400 });
   }

--- a/apps/finance/src/app/api/impersonation/me/route.ts
+++ b/apps/finance/src/app/api/impersonation/me/route.ts
@@ -38,11 +38,11 @@ export const GET = withAuth("impersonation:me", async (req: NextRequest, callerI
     .select("status, expires_at")
     .eq("id", session.grant_id)
     .single();
+  // null expires_at = indefinite grant; still active until target revokes.
   if (
     !grant ||
     grant.status !== "approved" ||
-    !grant.expires_at ||
-    new Date(grant.expires_at).getTime() < Date.now()
+    (grant.expires_at && new Date(grant.expires_at).getTime() < Date.now())
   ) {
     return NextResponse.json({ impersonating: false });
   }

--- a/apps/finance/src/components/ImpersonationBanner.tsx
+++ b/apps/finance/src/components/ImpersonationBanner.tsx
@@ -14,7 +14,7 @@ type Context = {
 };
 
 function formatExpiresIn(iso: string | null | undefined): string {
-  if (!iso) return "";
+  if (!iso) return "until revoked";
   const ms = new Date(iso).getTime() - Date.now();
   if (ms <= 0) return "expired";
   const mins = Math.floor(ms / 60_000);
@@ -89,7 +89,8 @@ export default function ImpersonationBanner() {
             {" "}— signed in via <strong className="font-medium">{ctx.requester_email}</strong>
           </>
         ) : null}
-        {ctx.expires_at ? <> · {formatExpiresIn(ctx.expires_at)}</> : null}
+        {" · "}
+        {formatExpiresIn(ctx.expires_at)}
       </span>
       <button
         onClick={exit}

--- a/apps/finance/src/components/ImpersonationRequestBanner.tsx
+++ b/apps/finance/src/components/ImpersonationRequestBanner.tsx
@@ -16,7 +16,10 @@ type Grant = {
   requester_email: string | null;
 };
 
-function formatDuration(seconds: number): string {
+function formatDuration(seconds: number): string | null {
+  // 0 = indefinite. Caller drops the suffix on the Approve button so it
+  // reads "Approve" rather than "Approve 0".
+  if (seconds === 0) return null;
   if (seconds >= 86_400) return `${seconds / 86_400}d`;
   if (seconds >= 3_600) return `${Math.round(seconds / 3_600)}h`;
   return `${Math.round(seconds / 60)}m`;
@@ -90,7 +93,8 @@ export default function ImpersonationRequestBanner() {
         <strong className="font-medium">
           {target.requester_email ?? "An admin"}
         </strong>{" "}
-        is requesting access to your account
+        is requesting{" "}
+        {target.duration_seconds === 0 ? "indefinite " : ""}access to your account
         {target.reason ? <> — “{target.reason}”</> : ""}.
       </span>
       <div className="flex items-center gap-2 flex-shrink-0">
@@ -99,7 +103,12 @@ export default function ImpersonationRequestBanner() {
           disabled={busy === target.id}
           className="text-xs font-medium px-2.5 py-1 rounded bg-[var(--color-accent)] text-[var(--color-on-accent)] hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
         >
-          {busy === target.id ? "…" : `Approve ${formatDuration(target.duration_seconds)}`}
+          {busy === target.id
+            ? "…"
+            : (() => {
+                const d = formatDuration(target.duration_seconds);
+                return d ? `Approve ${d}` : "Approve";
+              })()}
         </button>
         <button
           onClick={() => decide(target.id, "deny")}

--- a/apps/finance/src/lib/impersonation/status.ts
+++ b/apps/finance/src/lib/impersonation/status.ts
@@ -24,7 +24,9 @@ export type GrantRow = {
 
 export function isActive(grant: Pick<GrantRow, "status" | "expires_at">): boolean {
   if (grant.status !== "approved") return false;
-  if (!grant.expires_at) return false;
+  // Indefinite grants (duration 0) leave expires_at null; they remain
+  // active until the target revokes.
+  if (!grant.expires_at) return true;
   return new Date(grant.expires_at).getTime() > Date.now();
 }
 


### PR DESCRIPTION
## Summary

- Replaces the bare `<select>` + plain text input in the user drawer's Impersonation section with a row of pill toggles ("1h" / "1 day" / "1 week" / "Until revoked") and a properly styled reason input.
- "Request access", "Grant Pro", and "Enter session" now use `variant="primary"` — black-on-white in light mode, white-on-black in dark mode.
- Adds `duration_seconds=0` as a valid value meaning "until revoked." On approve, the route stores `expires_at=null`; every guard (start, begin, me, isActive helpers, banner, settings page) treats `null` as still valid so indefinite grants run until the target hits Revoke.

## Test plan

- [ ] Open admin user drawer → impersonation section shows pill duration toggles, "Until revoked" selectable
- [ ] "Request access" button is filled (not outlined) with inverted color
- [ ] "Grant Pro" button (when free user) is filled
- [ ] Request with "Until revoked" → user banner says "is requesting indefinite access"
- [ ] User approves → admin drawer shows "Active — until revoked"
- [ ] Enter session works; red banner shows "until revoked" instead of empty
- [ ] Revoke from settings page works for indefinite grant

🤖 Generated with [Claude Code](https://claude.com/claude-code)