### PR TITLE
feat(notifications): live updates + red dot + mobile sheet

### DIFF
--- a/apps/admin/src/app/(admin)/users/UserDrawer.tsx
+++ b/apps/admin/src/app/(admin)/users/UserDrawer.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import clsx from "clsx";
 import { Button, ConfirmOverlay, Drawer } from "@zervo/ui";
+import { createClient } from "@/lib/supabase/client";
 import { billableLinesForItem, formatUsd } from "@/lib/plaidPricing";
 import {
   type AdminUserRow,
@@ -104,6 +105,53 @@ export default function UserDrawer({
     setGrantError(null);
     setReason("");
   }, [user]);
+
+  // Subscribing per-drawer-instance ensures the channel is torn down
+  // when the admin closes or switches users. Reusing a single client
+  // across the app is fine — Supabase multiplexes channels over one
+  // websocket.
+  const supabase = useMemo(() => createClient(), []);
+
+  // Live updates for grant state — when the target approves/denies/
+  // revokes from their phone or another tab, the drawer flips without a
+  // refresh. We only apply UPDATE payloads for grants already in local
+  // state so events for grants belonging to OTHER admins (filter is on
+  // target_user_id, not requester) don't bleed in.
+  useEffect(() => {
+    if (!user) return;
+    const channel = supabase
+      .channel(`drawer-grants-${user.id}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "impersonation_grants",
+          filter: `target_user_id=eq.${user.id}`,
+        },
+        (payload) => {
+          const row = payload.new as {
+            id: string;
+            status: string;
+            expires_at: string | null;
+            decided_at: string | null;
+            duration_seconds: number;
+            requested_at: string;
+            reason: string | null;
+          } | null;
+          if (!row) return;
+          setGrants((prev) =>
+            prev.some((g) => g.id === row.id)
+              ? prev.map((g) => (g.id === row.id ? { ...g, ...row } : g))
+              : prev,
+          );
+        },
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [user, supabase]);
 
   async function requestImpersonation() {
     if (!user) return;

--- a/apps/finance/src/components/AlertsIcon.tsx
+++ b/apps/finance/src/components/AlertsIcon.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { FiBell } from "react-icons/fi";
+import { FiBell, FiX } from "react-icons/fi";
 import { useUser } from "./providers/UserProvider";
 import { useHouseholds } from "./providers/HouseholdsProvider";
 import { motion, AnimatePresence, Variants } from "framer-motion";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { authFetch } from "../lib/api/fetch";
+import { supabase } from "../lib/supabase/client";
 import { useToast } from "./providers/ToastProvider";
 import { TOOLTIP_SURFACE_CLASSES } from "@zervo/ui";
 
@@ -152,6 +153,46 @@ export default function AlertsIcon() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  // Live updates — when an admin requests impersonation access, or
+  // someone invites this user to a household, the relevant tray section
+  // refreshes the moment the row lands. We don't try to apply the change
+  // payload directly because the REST endpoints hydrate joined data
+  // (requester names, household name, etc.) that the WAL row doesn't
+  // carry; refetching is simpler and the lists are small.
+  useEffect(() => {
+    if (!profile?.id) return;
+    const channel = supabase
+      .channel(`alerts-${profile.id}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "impersonation_grants",
+          filter: `target_user_id=eq.${profile.id}`,
+        },
+        () => {
+          loadImpersonationRequests();
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "household_invitations",
+          filter: `invited_user_id=eq.${profile.id}`,
+        },
+        () => {
+          loadInvitations();
+        },
+      )
+      .subscribe();
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [profile?.id, loadImpersonationRequests, loadInvitations]);
+
   if (loading) return null;
 
   const jiggleVariants: Variants = {
@@ -247,7 +288,8 @@ export default function AlertsIcon() {
               initial={{ scale: 0 }}
               animate={{ scale: 1 }}
               exit={{ scale: 0 }}
-              className="absolute top-2 right-2 w-2 h-2 bg-[var(--color-fg)] rounded-full border-2 border-[var(--color-content-bg)]"
+              className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-[var(--color-danger)] rounded-full border-2 border-[var(--color-content-bg)]"
+              aria-label={`${totalCount} unread`}
             />
           )}
         </AnimatePresence>
@@ -255,18 +297,46 @@ export default function AlertsIcon() {
 
       <AnimatePresence>
         {isOpen && (
-          <motion.div
-            initial={{ opacity: 0, y: 8, scale: 0.98 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 8, scale: 0.98 }}
-            transition={{ duration: 0.14, ease: [0.25, 0.1, 0.25, 1] }}
-            className={`absolute top-full right-0 mt-2 w-80 z-50 overflow-hidden ${TOOLTIP_SURFACE_CLASSES}`}
-          >
-            <div className="px-5 pt-4 pb-2">
-              <h3 className="text-sm font-medium text-[var(--color-floating-fg)]">Notifications</h3>
-            </div>
+          <>
+            {/* Mobile backdrop. Tapping anywhere outside the sheet closes
+                it. The desktop dropdown's outside-click handler in the
+                effect above covers the >= sm case, so this is only here
+                to dim the page on small screens where the panel takes
+                over the full bottom of the viewport. */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.18 }}
+              onClick={() => setIsOpen(false)}
+              className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] sm:hidden"
+              aria-hidden
+            />
+            <motion.div
+              initial={{ opacity: 0, y: 16, scale: 1 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 16, scale: 1 }}
+              transition={{ duration: 0.18, ease: [0.25, 0.1, 0.25, 1] }}
+              className={`fixed inset-x-0 bottom-0 z-50 max-h-[85vh] w-full rounded-t-2xl flex flex-col sm:absolute sm:bottom-auto sm:inset-x-auto sm:top-full sm:right-0 sm:mt-2 sm:w-80 sm:max-h-none sm:rounded-2xl ${TOOLTIP_SURFACE_CLASSES}`}
+            >
+              {/* Drag handle on mobile so the sheet visually reads as
+                  dismissable; on sm+ it's hidden (the dropdown floats). */}
+              <div className="pt-2 pb-1 flex justify-center sm:hidden">
+                <span className="block h-1 w-9 rounded-full bg-[var(--color-floating-muted)]/40" />
+              </div>
+              <div className="px-5 pt-3 sm:pt-4 pb-2 flex items-center justify-between">
+                <h3 className="text-sm font-medium text-[var(--color-floating-fg)]">Notifications</h3>
+                <button
+                  type="button"
+                  onClick={() => setIsOpen(false)}
+                  className="sm:hidden p-1 rounded-full text-[var(--color-floating-muted)] hover:text-[var(--color-floating-fg)] transition-colors"
+                  aria-label="Close notifications"
+                >
+                  <FiX className="h-4 w-4" />
+                </button>
+              </div>
 
-            <div className="max-h-[420px] overflow-y-auto pb-2">
+              <div className="flex-1 overflow-y-auto pb-[max(env(safe-area-inset-bottom),0.5rem)] sm:pb-2 sm:max-h-[420px]">
               {impersonationRequests.length > 0 && (
                 <div>
                   {impersonationRequests.map((grant) => {
@@ -379,8 +449,9 @@ export default function AlertsIcon() {
                   <p className="text-sm text-[var(--color-floating-muted)]">You&apos;re all caught up</p>
                 </div>
               )}
-            </div>
-          </motion.div>
+              </div>
+            </motion.div>
+          </>
         )}
       </AnimatePresence>
     </div>

--- a/apps/finance/supabase/migrations/20260430184814_enable_realtime_grants_and_invitations.sql
+++ b/apps/finance/supabase/migrations/20260430184814_enable_realtime_grants_and_invitations.sql
@@ -1,0 +1,17 @@
+-- Enable Supabase Realtime on the two tables that drive the bell-icon
+-- notification tray, so:
+--   • a user's tray updates the moment an admin requests impersonation
+--     access, or another household member invites them
+--   • the admin's UserDrawer reflects approve/deny without a refresh
+--
+-- REPLICA IDENTITY FULL so UPDATE events ship every column. Without
+-- this, an update to `status` on impersonation_grants wouldn't include
+-- `target_user_id`/`requester_id` in the WAL row, and Realtime's
+-- per-channel filter (`target_user_id=eq.<uid>`) would drop the event.
+-- Both tables are low-volume — full replica identity is fine.
+
+alter table public.impersonation_grants replica identity full;
+alter table public.household_invitations replica identity full;
+
+alter publication supabase_realtime add table public.impersonation_grants;
+alter publication supabase_realtime add table public.household_invitations;


### PR DESCRIPTION
## Summary

- **Realtime publication** — adds \`impersonation_grants\` and \`household_invitations\` to \`supabase_realtime\` with \`REPLICA IDENTITY FULL\` so per-channel filters on \`target_user_id\` / \`invited_user_id\` work across UPDATE events even when those columns aren't the changed ones.
- **AlertsIcon live** — single per-user channel that fans out to refetches of pending invitations + impersonation requests on any insert/update/delete. Tray reflects new requests instantly, no polling.
- **UserDrawer live** — admin's open drawer subscribes to UPDATE events on grants targeting that user and applies the new row directly to local state. Drawer flips Pending → Active or Denied without the admin reloading.
- **Red dot** — bell-icon indicator now uses \`var(--color-danger)\` and is slightly larger, reading as "needs attention" instead of decorative.
- **Mobile sheet** — bell tray becomes a bottom sheet on small screens (\`fixed inset-x-0 bottom-0\`, rounded top, drag handle, X-to-close, dim backdrop) and stays a 320px floating dropdown on \`sm+\`. Single component, responsive Tailwind classes.

## Test plan

- [ ] On user A's tab, send an impersonation request from admin app → A's bell red dot appears within ~1s, tray shows the request without refresh
- [ ] User approves/denies → admin's open UserDrawer flips state without refresh
- [ ] On mobile viewport (< sm), tap bell → bottom sheet slides up, drag handle visible, X and backdrop dismiss it
- [ ] On desktop (≥ sm), tap bell → 320px floating dropdown unchanged
- [ ] Household invite from another user → invite appears in tray live

🤖 Generated with [Claude Code](https://claude.com/claude-code)