### PR TITLE
fix(agent): tz-aware date context, conversation summarization, refresh stale tools.ts comment

### DIFF
--- a/apps/finance/src/app/(main)/agent/AgentChat.tsx
+++ b/apps/finance/src/app/(main)/agent/AgentChat.tsx
@@ -462,6 +462,15 @@ export default function AgentChat({
     submittedText: string;
   }) {
     try {
+      // Source timezone from the browser. The chat route uses this to
+      // resolve "today" / "this month" against the user's calendar
+      // instead of the Vercel server's UTC, which drifts by a day near
+      // midnight or on month boundaries. Falls back to UTC server-side
+      // if Intl ever misbehaves or the value is unrecognised.
+      const browserTz =
+        typeof Intl !== "undefined"
+          ? Intl.DateTimeFormat().resolvedOptions().timeZone
+          : undefined;
       const res = await authFetch("/api/agent/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -469,6 +478,7 @@ export default function AgentChat({
           message,
           synthetic,
           conversation_id: conversation?.id ?? null,
+          timezone: browserTz,
         }),
       });
       if (!res.ok || !res.body) {

--- a/apps/finance/src/app/api/agent/chat/route.ts
+++ b/apps/finance/src/app/api/agent/chat/route.ts
@@ -11,6 +11,8 @@ import {
 } from '../../../../lib/agent/config';
 import { resolveAgentConfig } from '../../../../lib/agent/platformConfig';
 import { TOOLS, executeTool } from '../../../../lib/agent/tools';
+import { resolveTimeZone, todayYmdInTz } from '../../../../lib/agent/dates';
+import { ensureConversationSummary } from '../../../../lib/agent/summary';
 import type { Json } from '../../../../types/database';
 
 /**
@@ -45,6 +47,11 @@ interface ChatBody {
   // accept/decline so the agent moves to the next step automatically
   // without the user having to type "what's next?".
   synthetic?: boolean;
+  // IANA timezone of the user's browser (Intl.DateTimeFormat().
+  // resolvedOptions().timeZone). Used to anchor "today" / "this month"
+  // calculations to the user's local calendar instead of the server's
+  // UTC. Falls back to UTC if missing or unrecognised.
+  timezone?: string;
 }
 
 type AnthropicContentBlock = Anthropic.Messages.ContentBlock;
@@ -232,17 +239,22 @@ export const POST = withAuth('agent:chat', async (req: NextRequest, userId: stri
   // the user has no January 2024 data. Inject the current date in a couple
   // of formats so date-math prompts ("last month", "this week") resolve to
   // real calendar boundaries instead of hallucinations.
-  const now = new Date();
-  const isoToday = now.toISOString().slice(0, 10); // yyyy-MM-dd
-  const humanToday = now.toLocaleDateString('en-US', {
+  //
+  // Timezone is sourced from the client's Intl.DateTimeFormat — the
+  // server runs in UTC, so without this the model gets the UTC date,
+  // which can be a day off near midnight or on month boundaries.
+  const userTz = resolveTimeZone(body.timezone);
+  const isoToday = todayYmdInTz(userTz);
+  const humanToday = new Intl.DateTimeFormat('en-US', {
     weekday: 'long',
     month: 'long',
     day: 'numeric',
     year: 'numeric',
-  });
+    timeZone: userTz,
+  }).format(new Date());
   const dateContext =
     `# Date context\n\n` +
-    `Today is ${humanToday} (${isoToday}). ` +
+    `Today is ${humanToday} (${isoToday}) in the user's timezone (${userTz}). ` +
     `When the user mentions relative time ranges like "this month", "last month", or "last week", ` +
     `resolve them against this date. For tools that take a \`month\` parameter (YYYY-MM-DD), pass any ` +
     `date inside the target month — the tool normalizes to month boundaries internally.`;
@@ -295,18 +307,10 @@ export const POST = withAuth('agent:chat', async (req: NextRequest, userId: stri
   }
   const profileBlock = `\n\n# User profile\n\n${profileLines.join('\n')}`;
 
-  // Split the system block into a STATIC prefix and a DYNAMIC suffix so
-  // the cache breakpoint sits at the boundary between them. The static
-  // prefix (SYSTEM_PROMPT, ~7k tokens) almost never changes, so it stays
-  // a globally shared cache hit. The dynamic suffix (today's date,
-  // user's profile, saved memories, custom instructions) changes
-  // routinely — daily for the date, per-write for memory/profile — but
-  // it's small (~500 tokens) so sending it uncached every turn is cheap.
-  //
-  // Before this split, the entire 7k system block was concatenated into
-  // ONE cached entry. Adding a memory or crossing midnight UTC would
-  // bust the cache and force a full ~10k re-write that day.
-  const dynamicSuffix =
+  // Build the dynamic suffix — everything user/turn-specific that goes
+  // after the cached static prefix. Conversation summary (when one
+  // exists) is appended later, once we know the older window's size.
+  const baseDynamicSuffix =
     `${dateContext}${profileBlock}${memoriesBlock}` +
     (profile?.custom_instructions
       ? `\n\nUser's custom instructions:\n${profile.custom_instructions}`
@@ -331,13 +335,20 @@ export const POST = withAuth('agent:chat', async (req: NextRequest, userId: stri
   // (or any dev iteration), this is a net win. For one-and-done users
   // it's a small premium on the single request.
   const cacheControl = { type: 'ephemeral' as const, ttl: '1h' as const };
-  const cachedSystem: Anthropic.Messages.TextBlockParam[] = [
-    { type: 'text', text: SYSTEM_PROMPT, cache_control: cacheControl },
-    { type: 'text', text: dynamicSuffix },
-  ];
   const cachedTools: Anthropic.Messages.Tool[] = TOOLS.map((tool, i) =>
     i === TOOLS.length - 1 ? { ...tool, cache_control: cacheControl } : tool,
   );
+  const buildSystem = (
+    summaryText: string | null,
+  ): Anthropic.Messages.TextBlockParam[] => {
+    const summaryBlock = summaryText
+      ? `\n\n# Earlier conversation summary\n\nThe following summarises everything from this conversation that's older than the recent message window. Treat it as established context — names, numbers, decisions, and pending threads here have already happened. Don't ask the user to repeat them.\n\n${summaryText}`
+      : '';
+    return [
+      { type: 'text', text: SYSTEM_PROMPT, cache_control: cacheControl },
+      { type: 'text', text: `${baseDynamicSuffix}${summaryBlock}` },
+    ];
+  };
 
   const client = new Anthropic({ apiKey: agentConfig.apiKey });
   const encoder = new TextEncoder();
@@ -351,6 +362,12 @@ export const POST = withAuth('agent:chat', async (req: NextRequest, userId: stri
       send({ type: 'meta', conversation_id: conversationId });
 
       try {
+        // Conversation summary covers everything older than the recent
+        // message window. Computed once per turn (iteration 0); reused
+        // across iterations since within a single turn we add at most
+        // 2 × MAX_TOOL_ITERATIONS messages, well under the cap.
+        let summaryText: string | null = null;
+
         // Multi-iteration tool-use loop. Each iteration:
         //   - Loads current conversation history from DB.
         //   - Streams a model response.
@@ -369,12 +386,35 @@ export const POST = withAuth('agent:chat', async (req: NextRequest, userId: stri
             .map((r) => rowToAnthropicMessage({ role: r.role, content: r.content }))
             .filter((m): m is AnthropicMessageParam => m !== null);
 
+          // On the first iteration of this turn, refresh the
+          // conversation summary if the older window has grown since
+          // it was last cached. Long chats would otherwise lose
+          // everything past MAX_PRIOR_MESSAGES the moment we slice.
+          if (iter === 0) {
+            const olderCount = Math.max(0, history.length - MAX_PRIOR_MESSAGES);
+            if (olderCount > 0) {
+              try {
+                summaryText = await ensureConversationSummary({
+                  client,
+                  model: agentConfig.model,
+                  conversationId,
+                  olderMessages: history.slice(0, olderCount),
+                  olderCount,
+                });
+              } catch (summaryErr) {
+                // Don't fail the whole turn if summarization breaks —
+                // worst case we lose pre-window context for this turn.
+                logger.error('summary generation failed', summaryErr as Error);
+              }
+            }
+          }
+
           const trimmed = history.slice(-MAX_PRIOR_MESSAGES);
 
           const anthropicStream = client.messages.stream({
             model: agentConfig.model,
             max_tokens: MAX_RESPONSE_TOKENS,
-            system: cachedSystem,
+            system: buildSystem(summaryText),
             tools: cachedTools,
             messages: trimmed,
           });

--- a/apps/finance/src/lib/agent/dates.ts
+++ b/apps/finance/src/lib/agent/dates.ts
@@ -1,0 +1,33 @@
+/**
+ * Timezone helpers for the agent runtime.
+ *
+ * The chat route runs on Vercel in UTC. Without an explicit timezone
+ * the model gets UTC's idea of "today", which can be a day off for any
+ * user not in UTC — most visibly around midnight or on the first/last
+ * of the month. The browser sends its IANA timezone with each chat
+ * POST and we resolve "today" against it here.
+ */
+import { formatInTimeZone } from 'date-fns-tz';
+
+const FALLBACK_TZ = 'UTC';
+
+/**
+ * Validate that a string is an IANA timezone the runtime recognises.
+ * Accepts undefined / empty as a "use fallback" signal. Rejects anything
+ * Intl.DateTimeFormat throws on. Returning the validated string (or
+ * fallback) means callers don't need their own try/catch.
+ */
+export function resolveTimeZone(input: string | null | undefined): string {
+  if (!input || typeof input !== 'string') return FALLBACK_TZ;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: input });
+    return input;
+  } catch {
+    return FALLBACK_TZ;
+  }
+}
+
+/** Today as YYYY-MM-DD in the given timezone. */
+export function todayYmdInTz(tz: string): string {
+  return formatInTimeZone(new Date(), tz, 'yyyy-MM-dd');
+}

--- a/apps/finance/src/lib/agent/summary.ts
+++ b/apps/finance/src/lib/agent/summary.ts
@@ -1,0 +1,172 @@
+/**
+ * Conversation summarization.
+ *
+ * Long chats lose context the moment they exceed MAX_PRIOR_MESSAGES —
+ * the chat route slices the recent window and silently drops everything
+ * before it. This module produces and caches a compact summary of the
+ * dropped portion so the model retains the gist (numbers established,
+ * decisions reached, pending threads) past the recent-messages cap.
+ *
+ * Storage: encoded as JSON inside `user_agent_conversations.summary`
+ * (existing column, previously unused). Shape is `{ text, message_count }`
+ * so we can detect when the cached summary is stale relative to the
+ * current backlog. Plain-text rows (legacy or hand-edited) are treated
+ * as "no usable summary" and regenerated.
+ */
+import type Anthropic from '@anthropic-ai/sdk';
+import { supabaseAdmin } from '../supabase/admin';
+
+type AnthropicMessageParam = Anthropic.Messages.MessageParam;
+// Input-side block param — covers text, tool_use, AND tool_result. The
+// server-side ContentBlock omits tool_result (that's user-emitted),
+// which is exactly the block type the message history needs to handle.
+type AnthropicContentBlockParam = Anthropic.Messages.ContentBlockParam;
+
+interface StoredSummary {
+  text: string;
+  message_count: number;
+}
+
+function parseStoredSummary(raw: string | null | undefined): StoredSummary | null {
+  if (!raw || typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{')) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as Partial<StoredSummary>;
+    if (typeof parsed.text !== 'string' || typeof parsed.message_count !== 'number') {
+      return null;
+    }
+    return { text: parsed.text, message_count: parsed.message_count };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Render older messages into a compact transcript the summarizer model
+ * can read without us having to replay tool_use / tool_result blocks.
+ * We collapse:
+ *  - text blocks → plain text
+ *  - tool_use → `[called <name>(<short input>)]`
+ *  - tool_result → `[tool returned: <short output>]`
+ *
+ * Long blobs are truncated; the goal is a readable timeline, not a
+ * faithful replay.
+ */
+function flattenForSummary(messages: AnthropicMessageParam[]): string {
+  const lines: string[] = [];
+  for (const msg of messages) {
+    const role = msg.role === 'assistant' ? 'assistant' : 'user';
+    if (typeof msg.content === 'string') {
+      if (msg.content.trim()) lines.push(`${role}: ${msg.content.trim()}`);
+      continue;
+    }
+    for (const block of msg.content as AnthropicContentBlockParam[]) {
+      if (block.type === 'text') {
+        const text = block.text?.trim();
+        if (text) lines.push(`${role}: ${text}`);
+      } else if (block.type === 'tool_use') {
+        const inputJson = JSON.stringify(block.input ?? {});
+        const truncated = inputJson.length > 200 ? `${inputJson.slice(0, 200)}…` : inputJson;
+        lines.push(`assistant: [called ${block.name}(${truncated})]`);
+      } else if (block.type === 'tool_result') {
+        // tool_result content can itself be a string or an array of
+        // blocks. We only need a short trace, so stringify once.
+        const raw =
+          typeof block.content === 'string'
+            ? block.content
+            : JSON.stringify(block.content ?? '');
+        const truncated = raw.length > 300 ? `${raw.slice(0, 300)}…` : raw;
+        lines.push(`tool: ${truncated}`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+const SUMMARIZER_SYSTEM = `You are a summarizer for a personal finance chat between a user and an AI agent. Produce a compact, factual recap of the conversation that another AI agent will read at the top of its next turn so it doesn't repeat questions or contradict prior context.
+
+Cover:
+- Concrete facts established (numbers, account names, categories, budget amounts, dates).
+- Decisions reached (budgets accepted, recategorizations approved, income set).
+- Open threads or pending proposals the user has not yet accepted/declined.
+- Anything the user explicitly asked the agent to remember or do later.
+
+Skip:
+- Pleasantries, hedging, restatements.
+- Tool-call mechanics — only the substantive results matter.
+- The most recent few exchanges (those will still be in the live message window).
+
+Output 6-15 short bullet points. No headings, no preamble, no closing line.`;
+
+interface EnsureSummaryArgs {
+  client: Anthropic;
+  model: string;
+  conversationId: string;
+  olderMessages: AnthropicMessageParam[];
+  // Total count of messages BEFORE the recent window. Used as the
+  // staleness key — if it's grown since we last summarized, regenerate.
+  olderCount: number;
+}
+
+/**
+ * Returns the current summary text for `conversationId`, regenerating
+ * it via Anthropic if the cached summary is missing or out of date.
+ * Returns null if there's nothing to summarize (older window empty).
+ */
+export async function ensureConversationSummary({
+  client,
+  model,
+  conversationId,
+  olderMessages,
+  olderCount,
+}: EnsureSummaryArgs): Promise<string | null> {
+  if (olderCount <= 0 || olderMessages.length === 0) return null;
+
+  const { data: convRow } = await supabaseAdmin
+    .from('user_agent_conversations')
+    .select('summary')
+    .eq('id', conversationId)
+    .maybeSingle();
+
+  const cached = parseStoredSummary(convRow?.summary);
+  if (cached && cached.message_count >= olderCount) {
+    return cached.text;
+  }
+
+  // Need to (re)generate. Keep it tight — 800 tokens is plenty for the
+  // bullet-point style we ask for, and the cost is amortized across all
+  // future turns of this conversation that hit the same summary.
+  const transcript = flattenForSummary(olderMessages);
+  if (!transcript.trim()) return null;
+
+  const response = await client.messages.create({
+    model,
+    max_tokens: 800,
+    system: SUMMARIZER_SYSTEM,
+    messages: [
+      {
+        role: 'user',
+        content: `Summarize this earlier conversation:\n\n${transcript}`,
+      },
+    ],
+  });
+
+  const textBlocks = response.content.filter(
+    (b): b is Extract<Anthropic.Messages.ContentBlock, { type: 'text' }> =>
+      b.type === 'text',
+  );
+  const text = textBlocks
+    .map((b) => b.text)
+    .join('\n')
+    .trim();
+  if (!text) return null;
+
+  const stored: StoredSummary = { text, message_count: olderCount };
+  await supabaseAdmin
+    .from('user_agent_conversations')
+    .update({ summary: JSON.stringify(stored) })
+    .eq('id', conversationId);
+
+  return text;
+}

--- a/apps/finance/src/lib/agent/tools.ts
+++ b/apps/finance/src/lib/agent/tools.ts
@@ -9,8 +9,10 @@
  *     plain object (never throws to Anthropic — errors come back as
  *     `{ error: string }` so the model can see them and recover).
  *
- * Read-only for now. Write tools (modify budgets, recategorize
- * transactions) land in a follow-up commit with confirmation flows.
+ * Mix of read tools (get_*) and write-proposal tools (propose_*,
+ * remember_user_fact). Every write goes through a UI confirmation
+ * widget — the tool itself just builds the proposal payload and never
+ * mutates state directly.
  */
 import type Anthropic from '@anthropic-ai/sdk';
 import { format, startOfMonth, endOfMonth, subDays, subMonths } from 'date-fns';


### PR DESCRIPTION
Three fixes to the chat route after a code review:

1. **Timezone fix.** Date context was using server-local `new Date()` / `toLocaleDateString()`. Vercel runs in UTC, so for any user outside UTC the prompt's "today" could be a day off — most visibly around midnight or on the first/last of the month. The chat client now sends the browser's IANA timezone, the route validates it via `Intl.DateTimeFormat`, and the date block is formatted against that zone. Falls back to UTC when missing or unrecognised.

2. **Conversation summarization.** `user_agent_conversations.summary` existed in the schema but nothing wrote it. Once a chat exceeded `MAX_PRIOR_MESSAGES`, `history.slice(-N)` silently dropped older context. Added a small summarization pass that runs once per turn when the older window is non-empty, regenerates only when the older portion has grown since the cached summary, and prepends the result to the dynamic system suffix. Cached as JSON (`{ text, message_count }`) inside the existing column — no migration. Failures fall back to "no summary for this turn" rather than failing the turn.

3. **Stale `tools.ts` header comment.** Replaced "Read-only for now" with text reflecting the current read + write-proposal mix and the UI-confirmation contract.

Typecheck, lint, 385 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTz6ZwWPQPzmcw6XJyq6bX)_