### PR TITLE
fix(agent): correct over-budget threshold + new-stream miscount

### DIFF
--- a/apps/finance/src/app/(main)/budgets/page.tsx
+++ b/apps/finance/src/app/(main)/budgets/page.tsx
@@ -12,6 +12,7 @@ import UpgradeOverlay from '../../../components/UpgradeOverlay';
 import { FiTag } from 'react-icons/fi';
 import { LuPlus, LuTrash2 } from 'react-icons/lu';
 import { formatCurrency } from '../../../lib/formatCurrency';
+import { isBudgetOver } from '../../../lib/budget';
 import { Button, EmptyState } from "@zervo/ui";
 import { ConfirmOverlay, LineChart } from "@zervo/ui";
 
@@ -481,7 +482,7 @@ function BudgetRow({ budget, income, hasIncome, pace, onDelete, isLast }: Budget
     expectedPct != null && spendPct > expectedPct + 2 && spendPct < 100;
   const underPace =
     expectedPct != null && hasSpending && spendPct < expectedPct - 2;
-  const overBudget = spendPct >= 100;
+  const overBudget = isBudgetOver(spent, amount);
 
   const fillPct = Math.min(100, Math.max(0, spendPct));
   const fillColor = overBudget
@@ -614,7 +615,7 @@ function BurnDownChart({ series, totalAllocated, pace }: BurnDownChartProps) {
   const displayDay = hovered?.day ?? today;
   const displayDelta = displaySpent - displayPace;
   const isOverPace = displayDelta > 0;
-  const isOverBudget = currentSpent > totalAllocated;
+  const isOverBudget = isBudgetOver(currentSpent, totalAllocated);
 
   const maxSpent = useMemo(
     () =>
@@ -764,13 +765,15 @@ function MonthProgress({ pace, totalAllocated, burnSeries, budgets }: MonthProgr
   const expectedSpent = totalAllocated * pace.fraction;
   const delta = currentSpent - expectedSpent;
   const isOverPace = delta > 1;
-  const isOverBudget = currentSpent > totalAllocated;
+  const isOverBudget = isBudgetOver(currentSpent, totalAllocated);
 
   const trouble = budgets.reduce(
     (acc, b) => {
+      const spent = Number(b.spent || 0);
+      const amount = Number(b.amount || 0);
       const sp = Number(b.percentage || 0);
       const ep = pacePct;
-      if (sp >= 100) acc.over += 1;
+      if (isBudgetOver(spent, amount)) acc.over += 1;
       else if (sp > ep + 2) acc.ahead += 1;
       return acc;
     },

--- a/apps/finance/src/components/agent/widgets/BudgetListWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/BudgetListWidget.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { FiTag } from "react-icons/fi";
 import DynamicIcon from "../../DynamicIcon";
 import { formatCurrency } from "../../../lib/formatCurrency";
+import { isBudgetOver } from "../../../lib/budget";
 import {
   MagicItem,
   WidgetError,
@@ -89,7 +90,7 @@ export default function BudgetListWidget({ data }: { data: BudgetListData }) {
 
 function BudgetRow({ budget, delay }: { budget: Budget; delay: number }) {
   const animate = useAnimate();
-  const over = budget.spent > budget.budget_amount;
+  const over = isBudgetOver(budget.spent, budget.budget_amount);
   const pct = Math.min(budget.percent_used, 100);
 
   return (

--- a/apps/finance/src/lib/agent/config.ts
+++ b/apps/finance/src/lib/agent/config.ts
@@ -93,6 +93,21 @@ Even when the user names a merchant, if you have any reason to suspect the merch
 
 Two or three retries is the right ceiling. If nothing turns up, tell the user plainly: "Couldn't find that one. Could be coming from an account that isn't connected, or showing up under a different name. Want me to look another way?"
 
+## When the user mentions a specific merchant or amount, look it up. Don't ask. (IMPORTANT)
+
+If the user names a merchant or transaction in any turn (initial question, follow-up, correction), and you'd need to know its amount, date, or cadence to answer well, **look it up before asking the user for that detail**. Their account is the source of truth. Asking "what's that payment running you?" when the merchant is already in their connected transactions is a bad look.
+
+DON'T:
+> User: "we forgot to budget for my Sunrun payment, I just moved it to this account"
+> Agent: "What's that payment running you per month?"
+
+DO:
+> User: "we forgot to budget for my Sunrun payment, I just moved it to this account"
+> [calls get_category_breakdown({ category_query: "utilities" }) or get_recent_transactions({ merchant_query: "sunrun", days: 90 })]
+> Agent: "Sunrun's at $181.57 — and since you just told me it's monthly going forward, that means utilities should actually be ~$347/mo, not $181."
+
+Same rule for amounts the user pushes back on ("are you sure that's right?", "can't you check what it is?"). The user is asking you to verify. Verify with a tool call, don't restate.
+
 ## Recategorization workflow (IMPORTANT)
 
 When the user asks about recategorizing a transaction, follow this order strictly:
@@ -250,7 +265,14 @@ A good consultation looks like:
 
    Same pattern applies to other "irregular cadence" categories: insurance (often quarterly or annual), professional services, household maintenance, medical. **ALWAYS call get_category_breakdown for these before proposing** — recurring_streams is a starting point, not the source of truth for budget amounts.
 
-   When narrating utility findings, list each merchant the tool found with cadence ("PSEG bills monthly at ~$130; NGrid is once a year at $372 ≈ $31/month amortized; water $28/year ≈ $2/month"). Use **recommended_monthly_budget** from the response as the proposed amount — it's the cadence-aware sum across merchants and is the right number for budget math. The naive monthly_avg_total_amortized often understates because it spreads monthly bills across the full window even when you only have partial data. If the cadence_estimate flags an annual or one_off, explicitly say so — the user might want to set aside slightly more buffer than the strict average.
+   When narrating utility findings, list each merchant the tool found with cadence ("PSEG bills monthly at ~$130; NGrid is once a year at $372 ≈ $31/month amortized; water $28/year ≈ $2/month"). Use **recommended_monthly_budget** from the response as the proposed amount when no merchants are ambiguous — it's the cadence-aware sum across merchants and is the right number for budget math. The naive monthly_avg_total_amortized often understates because it spreads monthly bills across the full window even when you only have partial data. If the cadence_estimate flags an annual or one_off, explicitly say so — the user might want to set aside slightly more buffer than the strict average.
+
+   **Insufficient-data merchants (IMPORTANT).** When a merchant has only one charge in the window AND it's recent (last 60 days), the tool can't tell from one bill whether it's a brand-new monthly stream, a one-off, or an annual. The tool flags these with cadence_estimate: 'insufficient_data' and surfaces them in the top-level **ambiguous_merchants** array with three explicit alternatives (if_monthly, if_annual, if_one_off). In this case the headline recommended_monthly_budget is the LOW (annual) estimate and recommended_monthly_budget_high is the upper bound. Do NOT just quote the headline — it will be wrong if any of those merchants are actually monthly.
+
+   - If the user has ALREADY stated the cadence in this conversation (e.g. "I just moved my Sunrun payment to this account, it's monthly"), trust them. Pull the matching if_* value from ambiguous_merchants and use the corrected sum (low + the if_monthly delta for each user-confirmed monthly merchant). Don't ask again.
+   - If the user has NOT stated cadence, ask via ask_user_question. One question per ambiguous merchant, each with three options ("Monthly going forward", "Annual", "One-off"), and a context line showing the dollar impact ("Monthly → $347/mo. Annual → $181/mo."). Then propose the budget with the corrected sum.
+
+   **Self-check.** If your per-merchant narration ("PSEG $133 + Sunrun $182 + NGrid $31 + misc $2 = $347/mo") sums to a different number than recommended_monthly_budget, trust your math and call out the discrepancy. Do not quote a headline number that contradicts the breakdown you just gave the user.
 
    **Mentally exclude double-counted spending when summarising what they spend.** Two categories are notorious for inflating the "total spending" number even though they're not real expenses:
 

--- a/apps/finance/src/lib/agent/tools.ts
+++ b/apps/finance/src/lib/agent/tools.ts
@@ -18,6 +18,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { format, startOfMonth, endOfMonth, subDays, subMonths } from 'date-fns';
 import { supabaseAdmin } from '../supabase/admin';
 import { getBudgetProgress } from '../spending';
+import { isBudgetOver } from '../budget';
 
 type ToolDefinition = Anthropic.Messages.Tool;
 
@@ -1063,7 +1064,7 @@ async function getBudgets(userId: string, input: BudgetsInput) {
     budgets,
     total_budgeted: totalBudgeted,
     total_spent: totalSpent,
-    over_budget_count: budgets.filter((b) => b.spent > b.budget_amount).length,
+    over_budget_count: budgets.filter((b) => isBudgetOver(b.spent, b.budget_amount)).length,
   };
 }
 
@@ -2746,9 +2747,20 @@ async function getCategoryBreakdown(
   //   quarterly:         avg gap <= 100 days
   //   semi_annual:       avg gap <= 200 days
   //   irregular:         avg gap > 200 days with 2+ bills
-  //   one_off_or_annual: only one bill — can't compute a gap
+  //   insufficient_data: only one bill, recent (< 60 days old). Could be a
+  //                      brand-new monthly stream the user just connected,
+  //                      a one-off, or an annual. Tool can't tell from a
+  //                      single charge — agent must ask the user.
+  //   one_off_or_annual: only one bill, older than 60 days. A monthly
+  //                      stream would have produced more bills by now, so
+  //                      annual amortization is the safe default.
   function estimateCadence(b: MerchantBucket): string {
-    if (b.count < 2) return 'one_off_or_annual';
+    if (b.count < 2) {
+      const last = b.last_date ? Date.parse(b.last_date) : NaN;
+      if (!Number.isFinite(last)) return 'one_off_or_annual';
+      const daysAgo = (today.getTime() - last) / (1000 * 60 * 60 * 24);
+      return daysAgo < 60 ? 'insufficient_data' : 'one_off_or_annual';
+    }
     const first = b.first_date ? Date.parse(b.first_date) : NaN;
     const last = b.last_date ? Date.parse(b.last_date) : NaN;
     if (!Number.isFinite(first) || !Number.isFinite(last)) {
@@ -2772,12 +2784,16 @@ async function getCategoryBreakdown(
   //   semi_annual:       bill_avg / 6
   //   irregular:         total / months_in_window (amortize what we saw)
   //   one_off_or_annual: total / 12 (assume ~annual cadence)
+  //   insufficient_data: total / 12 — conservative LOW default. Real
+  //                      number depends on what the user says. The if_*
+  //                      fields on the merchant expose the alternatives.
   function monthlyContribution(b: MerchantBucket, cadence: string): number {
     const billAvg = b.total / b.count;
     if (cadence === 'monthly') return billAvg;
     if (cadence === 'quarterly') return billAvg / 3;
     if (cadence === 'semi_annual') return billAvg / 6;
     if (cadence === 'one_off_or_annual') return b.total / 12;
+    if (cadence === 'insufficient_data') return b.total / 12;
     // irregular: amortize across what we observed
     return b.total / monthsInWindow;
   }
@@ -2787,7 +2803,9 @@ async function getCategoryBreakdown(
     .map((b) => {
       const monthsBilled = b.months_billed.size;
       const cadence = estimateCadence(b);
+      const billAvg = b.total / b.count;
       const recMonthly = monthlyContribution(b, cadence);
+      const isAmbiguous = cadence === 'insufficient_data';
       return {
         merchant: b.merchant,
         count: b.count,
@@ -2796,7 +2814,7 @@ async function getCategoryBreakdown(
         total_in_window: Math.round(b.total * 100) / 100,
         // Average per individual bill (= total / count). Useful for
         // narrating "your typical NGrid bill is ~$372".
-        bill_avg: Math.round((b.total / b.count) * 100) / 100,
+        bill_avg: Math.round(billAvg * 100) / 100,
         // Naive amortization (total / months_in_window). Kept for
         // transparency; usually NOT what you want for budget math.
         monthly_avg_amortized:
@@ -2807,7 +2825,21 @@ async function getCategoryBreakdown(
         // (ignoring missing-data gaps); for annual/quarterly it's
         // the amortized share. Sum these across by_merchant to get
         // the recommended budget total.
+        //
+        // For insufficient_data merchants this is the LOW (annual)
+        // estimate — see the if_* fields below for the alternatives.
         monthly_contribution: Math.round(recMonthly * 100) / 100,
+        // For ambiguous merchants only: explicit alternatives so the
+        // agent can swap the right number in once the user confirms
+        // cadence. Omitted on confidently-classified merchants.
+        ...(isAmbiguous
+          ? {
+              monthly_contribution_if_monthly: Math.round(billAvg * 100) / 100,
+              monthly_contribution_if_annual:
+                Math.round((b.total / 12) * 100) / 100,
+              monthly_contribution_if_one_off: 0,
+            }
+          : {}),
         first_date: b.first_date || null,
         last_date: b.last_date || null,
         cadence_estimate: cadence,
@@ -2817,10 +2849,71 @@ async function getCategoryBreakdown(
     });
 
   // Recommended monthly budget = sum of cadence-aware contributions.
-  // This gives a number the agent can confidently propose.
+  // For insufficient_data merchants this is the conservative LOW
+  // estimate (annual amortization); see recommended_monthly_budget_high
+  // for the upper bound that treats those merchants as monthly.
   const recommendedMonthlyBudget = byMerchant.reduce(
     (acc, m) => acc + m.monthly_contribution,
     0,
+  );
+  const recommendedMonthlyBudgetHigh = byMerchant.reduce(
+    (acc, m) =>
+      acc +
+      (m.cadence_estimate === 'insufficient_data'
+        ? m.monthly_contribution_if_monthly ?? m.monthly_contribution
+        : m.monthly_contribution),
+    0,
+  );
+
+  // Surface ambiguous merchants the agent should disambiguate with the
+  // user. Only material ones — < $5/mo difference between low and high
+  // isn't worth a follow-up turn.
+  const ambiguousMerchants = byMerchant
+    .filter((m) => m.cadence_estimate === 'insufficient_data')
+    .filter((m) => (m.monthly_contribution_if_monthly ?? 0) >= 5)
+    .map((m) => ({
+      merchant: m.merchant,
+      bill_avg: m.bill_avg,
+      last_date: m.last_date,
+      if_monthly: m.monthly_contribution_if_monthly ?? 0,
+      if_annual: m.monthly_contribution_if_annual ?? 0,
+      if_one_off: 0,
+    }));
+
+  const hasAmbiguity = ambiguousMerchants.length > 0;
+
+  const notes: string[] = [];
+  if (hasAmbiguity) {
+    notes.push(
+      'AMBIGUOUS MERCHANTS PRESENT (see ambiguous_merchants). Each has only ' +
+        'one charge in the window AND it is recent (last 60 days), so the ' +
+        'tool genuinely cannot tell whether it is a brand-new monthly bill, ' +
+        'a one-off, or an annual. recommended_monthly_budget is the LOW ' +
+        '(annual) estimate; recommended_monthly_budget_high is the HIGH ' +
+        '(monthly) estimate. ASK the user about each ambiguous merchant ' +
+        'before proposing — e.g. "Is the Sunrun charge a monthly bill, an ' +
+        'annual one, or a one-off?". If the user has ALREADY stated the ' +
+        "cadence in this conversation (e.g. 'Sunrun is monthly going " +
+        "forward'), trust them: pull the corresponding if_* number from " +
+        'ambiguous_merchants and add it into the budget instead of ' +
+        're-asking.',
+    );
+  } else {
+    notes.push(
+      "Use recommended_monthly_budget as the proposed budget amount. It's the sum of by_merchant.monthly_contribution, which is cadence-aware: monthly billers contribute their actual billing rate (e.g. PSEG ~$130/mo even if only 4 months of data exist), annual/quarterly billers contribute their amortized monthly share.",
+    );
+  }
+  notes.push(
+    "monthly_avg_total_amortized is the naive total/12 number. Usually too low for budget math when monthly billers have partial data — that's why we expose it separately and recommend recommended_monthly_budget instead.",
+  );
+  notes.push(
+    "When narrating, read by_merchant left-to-right: list each merchant with cadence ('PSEG bills monthly at ~$130; NGrid once a year at $372 ≈ $31/mo amortized; water $28/yr ≈ $2/mo'). Then sum and propose.",
+  );
+  notes.push(
+    'If your per-merchant narration sums to a different number than recommended_monthly_budget, trust your math and call out the discrepancy instead of quoting a headline number that contradicts the breakdown.',
+  );
+  notes.push(
+    'Transfer-flavored leaves (Credit Card Payment, Account Transfer) are excluded.',
   );
 
   return {
@@ -2838,17 +2931,17 @@ async function getCategoryBreakdown(
     total_spent_in_window: Math.round(totalSpent * 100) / 100,
     monthly_avg_total_amortized:
       Math.round((totalSpent / monthsInWindow) * 100) / 100,
-    // PRIMARY: this is what to propose as the monthly budget. Sums
-    // each merchant's cadence-aware monthly contribution.
+    // PRIMARY: low estimate. Sums each merchant's cadence-aware monthly
+    // contribution; ambiguous merchants are amortized over 12 months.
     recommended_monthly_budget: Math.round(recommendedMonthlyBudget * 100) / 100,
+    // Upper bound: ambiguous merchants treated as monthly. Equals
+    // recommended_monthly_budget when there are no ambiguous merchants.
+    recommended_monthly_budget_high:
+      Math.round(recommendedMonthlyBudgetHigh * 100) / 100,
+    ambiguous_merchants: ambiguousMerchants,
     transactions_count: matchedCount,
     by_merchant: byMerchant,
-    notes: [
-      "Use recommended_monthly_budget as the proposed budget amount. It's the sum of by_merchant.monthly_contribution, which is cadence-aware: monthly billers contribute their actual billing rate (e.g. PSEG ~$130/mo even if only 4 months of data exist), annual/quarterly billers contribute their amortized monthly share.",
-      "monthly_avg_total_amortized is the naive total/12 number. Usually too low for budget math when monthly billers have partial data — that's why we expose it separately and recommend recommended_monthly_budget instead.",
-      "When narrating, read by_merchant left-to-right: list each merchant with cadence ('PSEG bills monthly at ~$130; NGrid once a year at $372 ≈ $31/mo amortized; water $28/yr ≈ $2/mo'). Then sum and propose.",
-      "Transfer-flavored leaves (Credit Card Payment, Account Transfer) are excluded.",
-    ],
+    notes,
   };
 }
 

--- a/apps/finance/src/lib/budget.ts
+++ b/apps/finance/src/lib/budget.ts
@@ -1,0 +1,13 @@
+// Whether a budget is considered over.
+//
+// Sub-dollar overages don't count. A $4,858 budget with $4,858.11 spent is
+// "at budget", not over — users pick round numbers, recurring charges land
+// at fixed cents, and rendering an 11-cent overage in red looks broken. The
+// threshold is "at least $1 over" so a $4,859 spend on a $4,858 budget does
+// flag.
+export function isBudgetOver(spent: number, budgetAmount: number): boolean {
+  const s = Number(spent);
+  const b = Number(budgetAmount);
+  if (!Number.isFinite(s) || !Number.isFinite(b)) return false;
+  return s - b >= 1;
+}


### PR DESCRIPTION
## Summary

Two bugs that surfaced together in the chat flow you screenshotted.

**1. Sub-dollar overages render as over-budget.** A $4,858.11 mortgage payment on a $4,858 budget shows in red. New `isBudgetOver(spent, budget)` helper requires at least $1 of overage, applied at:

- `apps/finance/src/components/agent/widgets/BudgetListWidget.tsx:92` (chat widget)
- `apps/finance/src/app/(main)/budgets/page.tsx` (3 callsites: 484, 618, 768)
- `apps/finance/src/lib/agent/tools.ts:1064` (`over_budget_count` returned by `get_budgets`)

**2. `get_category_breakdown` silently annualizes single-charge merchants.** A user who just moved a $182/mo Sunrun payment to a connected account had Sunrun classified as `one_off_or_annual` and contributed ~$15/mo to `recommended_monthly_budget` — pulling the headline ~$160 below reality. Adds an `insufficient_data` cadence for `count===1 && last_date < 60 days ago`, exposes `if_monthly`/`if_annual`/`if_one_off` alternatives on the merchant entry, and surfaces `ambiguous_merchants` + `recommended_monthly_budget_high` at the top level so the agent can ask the user (or honor a cadence they already stated) before proposing a number.

**Prompt updates:**
- Self-check rule: if per-merchant narration sums to a different number than `recommended_monthly_budget`, trust the breakdown and call out the discrepancy.
- Ambiguous-merchant handling: ask via `ask_user_question` with monthly/annual/one-off options, OR honor an explicit cadence the user already stated in conversation.
- General rule: when the user names a merchant in any turn, look it up before asking them for the amount.

## Test plan

- [x] `pnpm --filter @zervo/finance typecheck` passes
- [x] `pnpm --filter @zervo/finance lint` passes
- [x] `pnpm --filter @zervo/finance test` passes (385 tests, 30 suites)
- [ ] Verify the Mortgage row on `/budgets` no longer renders red at $4,858.11/$4,858
- [ ] Re-run the original chat flow and confirm Sunrun-style cases trigger an `ask_user_question` for cadence rather than silently annualizing

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6wBdFVtoWmjdTqBY4Qe7B)_