### PR TITLE
Unify sidebar bg with content + swap ellipsis for user avatar

### DIFF
--- a/apps/finance/src/components/layout/AppShell.tsx
+++ b/apps/finance/src/components/layout/AppShell.tsx
@@ -189,31 +189,21 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <AgentOverlayProvider>
-    <div className="min-h-screen bg-[var(--color-shell-bg)] relative">
-      {/* Ambient blue glow lives on body::before in globals.css — it needs
-          to cover the full viewport including portaled modals, which means
-          it can't live inside any React-rendered stacking context. */}
+    <div className="min-h-screen bg-[var(--color-content-bg)] relative">
       {/* Impersonation banner is fixed full-width across the top — it
           sets --impersonation-banner-h on documentElement so the sidebar
-          + topbar shift down to clear it. Mounted here (outside the
-          sidebar-offset wrapper) is purely organizational; with `fixed`
-          positioning its DOM location doesn't matter, but the visual
-          intent reads better. */}
+          + topbar shift down to clear it. */}
       <ImpersonationBanner />
       <Sidebar />
-      {/* Floating sidebar lives at left:12px with width 56px — content
-          starts past the right edge of the sidebar plus a 12px breathing
-          gap (12 + 56 + 12 = 80px). On mobile (<md) the sidebar is
-          hidden and the drawer trigger lives in the topbar, so no left
-          offset is applied. */}
+      {/* Sidebar floats at left:12 with w:14 (56px); content starts past
+          its right edge plus a 12px breathing gap (12 + 56 + 12 = 80px).
+          The sidebar and main content share the same bg so there's no
+          card seam — the active-item indicator on each nav row carries
+          the visual weight instead. */}
       <div className="min-h-screen flex flex-col md:pl-20 relative pt-[var(--impersonation-banner-h,0px)]">
         <PaymentFailureBanner />
-        {/* Main content sits inside the shell with content-bg, leaving
-            the shell-bg visible behind the floating sidebar. The
-            AppTopbar lives inside this card so the card encompasses
-            every product surface. */}
         <main className="flex-1 flex flex-col">
-          <div className="flex-1 bg-[var(--color-content-bg)] flex flex-col">
+          <div className="flex-1 flex flex-col">
             <AppTopbar />
             <div
               className={

--- a/apps/finance/src/components/layout/SidebarContent.tsx
+++ b/apps/finance/src/components/layout/SidebarContent.tsx
@@ -61,7 +61,7 @@ export default function SidebarContent({ onNavigate }: { onNavigate?: () => void
   const isItemActive = (itemHref: string) => pathname.startsWith(itemHref);
 
   return (
-    <div className="flex h-full w-full flex-col bg-[var(--color-content-bg)] rounded-3xl border border-[var(--color-fg)]/[0.06] shadow-[0_2px_12px_rgba(0,0,0,0.04)] py-3">
+    <div className="flex h-full w-full flex-col py-3">
       <div className="flex justify-center pb-2">
         <HouseholdScopePopover />
       </div>

--- a/apps/finance/src/components/layout/SidebarMoreMenu.tsx
+++ b/apps/finance/src/components/layout/SidebarMoreMenu.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import clsx from "clsx";
-import { LuEllipsis, LuSparkles, LuHeadphones } from "react-icons/lu";
+import { LuSparkles, LuHeadphones } from "react-icons/lu";
 import { TbLogout } from "react-icons/tb";
 import { FaLock } from "react-icons/fa";
 import { ConfirmOverlay, Tooltip, TOOLTIP_SURFACE_CLASSES } from "@zervo/ui";
@@ -26,7 +26,7 @@ export default function SidebarMoreMenu() {
   const router = useRouter();
   const { profile, user, logout } = useUser();
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const [pos, setPos] = useState<{ bottom: number; left: number } | null>(null);
   const [showUpgrade, setShowUpgrade] = useState(false);
   const [showLogout, setShowLogout] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
@@ -53,6 +53,17 @@ export default function SidebarMoreMenu() {
         .join(" ")
     : user?.email || "";
   const tier = profile?.subscription_tier ?? "free";
+  const initials =
+    firstName && lastName
+      ? `${firstName[0]}${lastName[0]}`.toUpperCase()
+      : firstName
+        ? firstName[0].toUpperCase()
+        : (user?.email?.[0]?.toUpperCase() ?? "?");
+  const avatarUrl =
+    profile?.avatar_url ||
+    (meta.avatar_url as string | undefined) ||
+    (meta.picture as string | undefined) ||
+    null;
 
   useEffect(() => {
     if (!open) return;
@@ -73,16 +84,22 @@ export default function SidebarMoreMenu() {
     };
   }, [open]);
 
-  // Anchor the popover to the right edge of the trigger; bottom-align with
-  // the trigger center via translateY(-100%) so the menu grows upward
-  // from the button (it's at the bottom of the sidebar — opening upward
-  // keeps it on-screen).
+  // Anchor the popover to the right edge of the trigger and bottom-align
+  // with the trigger's bottom edge so it grows upward from the button
+  // (which sits at the bottom of the sidebar — opening upward keeps the
+  // menu fully on-screen). We use `bottom` for vertical anchoring instead
+  // of `top + translateY(-100%)` because framer-motion animates `x`/`y`
+  // via the same `transform` property and would clobber a static
+  // translateY.
   useEffect(() => {
     if (!open) return;
     const reposition = () => {
       const rect = triggerRef.current?.getBoundingClientRect();
       if (!rect) return;
-      setPos({ top: rect.bottom, left: rect.right + POPOVER_GAP });
+      setPos({
+        bottom: window.innerHeight - rect.bottom,
+        left: rect.right + POPOVER_GAP,
+      });
     };
     reposition();
     window.addEventListener("scroll", reposition, true);
@@ -120,21 +137,32 @@ export default function SidebarMoreMenu() {
 
   return (
     <>
-      <Tooltip content="More" side="right">
+      <Tooltip content={fullName || "Account"} side="right">
         <button
           ref={triggerRef}
           type="button"
           onClick={() => setOpen((v) => !v)}
-          aria-label="More menu"
+          aria-label="Account menu"
           aria-expanded={open}
           className={clsx(
-            "flex items-center justify-center w-10 h-10 rounded-md transition-colors cursor-pointer",
+            "flex items-center justify-center w-10 h-10 rounded-full transition-shadow cursor-pointer",
+            "ring-offset-2 ring-offset-[var(--color-content-bg)]",
             open
-              ? "text-[var(--color-fg)] bg-[var(--color-fg)]/[0.08]"
-              : "text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-fg)]/[0.05]",
+              ? "ring-2 ring-[var(--color-fg)]/20"
+              : "hover:ring-2 hover:ring-[var(--color-fg)]/15",
           )}
         >
-          <LuEllipsis className="h-[18px] w-[18px]" />
+          <span className="relative h-8 w-8 rounded-full bg-[var(--color-accent)] flex items-center justify-center text-[11px] font-semibold text-[var(--color-on-accent,white)] overflow-hidden">
+            {avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt={fullName || "Account"}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              initials
+            )}
+          </span>
         </button>
       </Tooltip>
 
@@ -151,10 +179,9 @@ export default function SidebarMoreMenu() {
                 transition={{ duration: 0.15 }}
                 style={{
                   position: "fixed",
-                  top: pos.top,
+                  bottom: pos.bottom,
                   left: pos.left,
                   width: POPOVER_WIDTH,
-                  transform: "translateY(-100%)",
                   zIndex: 100,
                 }}
                 className={clsx(


### PR DESCRIPTION
## Summary
- Drop the rounded card visual on the sidebar (no bg, border, or shadow) and switch the shell from `--color-shell-bg` to `--color-content-bg`. The sidebar and main content now share one continuous surface — no card seam between them. The active-row indicator carries the visual weight.
- Replace the `…` trigger on the more menu with a small user avatar (initials or photo). The ellipsis didn't communicate "open the account menu" the way an avatar does.
- Fix the popover direction: framer-motion animates `x`/`y` via the same `transform` property and was clobbering the static `translateY(-100%)`, so the menu opened downward off-screen. Anchor with `bottom` instead so the popover grows upward from the trigger and stays on-screen.

## QA
Verified locally via Playwright on a 1440×900 viewport against a dev server with mocked Supabase auth:
- `/dashboard`: sidebar at `x:12, y:12, w:56, h:876`, sidebar bg matches main content, active-state indicator on Dashboard icon.
- `/transactions`: active indicator animates to the Transactions icon.
- Account menu: avatar trigger opens a popover anchored to the right of the trigger that grows upward, showing user identity + Upgrade / Help / Log out.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsdQbUcZMUZmrzyDQBR3tQ)_