### PR TITLE
Add subtle shadow + rounded corners to floating sidebar

### DIFF
--- a/apps/finance/src/components/layout/SidebarContent.tsx
+++ b/apps/finance/src/components/layout/SidebarContent.tsx
@@ -61,7 +61,7 @@ export default function SidebarContent({ onNavigate }: { onNavigate?: () => void
   const isItemActive = (itemHref: string) => pathname.startsWith(itemHref);
 
   return (
-    <div className="flex h-full w-full flex-col py-3">
+    <div className="flex h-full w-full flex-col py-3 rounded-[20px] bg-[var(--color-content-bg)] shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_16px_rgba(0,0,0,0.04)]">
       <div className="flex justify-center pb-2">
         <HouseholdScopePopover />
       </div>


### PR DESCRIPTION
## Summary
Unifying the page bg in the previous PR removed the seam between the sidebar and content, but it also flattened the sidebar — the icons read as loose floats with no defined shape.

This adds a soft drop shadow and a 20px radius so the sidebar reads as a floating pill again, while keeping its bg in sync with the main content (no card-on-card seam, just lift).

```
shadow: 0 1px 3px rgba(0,0,0,.04), 0 4px 16px rgba(0,0,0,.04)
radius: 20px
bg:     var(--color-content-bg)  (unchanged — matches main)
```

## QA
Compared 7 visual treatments side by side via Playwright (subtle shadow / hairline border / darker bg / content-as-card / gray-shell / border+shadow combo / current). Picked subtle-shadow as the cleanest — defines the pill without introducing a second surface color or a hard edge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsdQbUcZMUZmrzyDQBR3tQ)_