### PR TITLE
Move profile to top of sidebar, ellipsis at bottom

### DIFF
--- a/apps/finance/src/components/households/HouseholdScopePopover.tsx
+++ b/apps/finance/src/components/households/HouseholdScopePopover.tsx
@@ -9,8 +9,9 @@ import clsx from "clsx";
 import { LuPlus } from "react-icons/lu";
 import { TOOLTIP_SURFACE_CLASSES } from "@zervo/ui";
 import { useHouseholds } from "../providers/HouseholdsProvider";
+import { useUser } from "../providers/UserProvider";
 import HouseholdSwitcherModal from "./HouseholdSwitcherModal";
-import { HouseholdTile, PersonalTile, ScopeAvatar } from "./ScopeSwitcher";
+import { HouseholdTile, PersonalTile } from "./ScopeSwitcher";
 
 /**
  * Compact scope switcher used in the tablet sidebar (collapsed at 80px).
@@ -28,6 +29,7 @@ const ROW_CLASS =
 export default function HouseholdScopePopover() {
   const pathname = usePathname();
   const { households } = useHouseholds();
+  const { profile, user } = useUser();
   const [open, setOpen] = useState(false);
   const [showSwitcher, setShowSwitcher] = useState(false);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
@@ -158,6 +160,29 @@ export default function HouseholdScopePopover() {
     </AnimatePresence>
   );
 
+  // In personal scope the trigger renders the user's own avatar so the
+  // top of the sidebar reads as identity-first; switching is a secondary
+  // action behind the click. In household scope it renders the household
+  // tile so the trigger always reflects the active context.
+  const meta =
+    (user as unknown as { user_metadata?: Record<string, unknown> })
+      ?.user_metadata ?? {};
+  const firstName =
+    profile?.first_name || (meta.first_name as string | undefined) || "";
+  const lastName =
+    profile?.last_name || (meta.last_name as string | undefined) || "";
+  const initials =
+    firstName && lastName
+      ? `${firstName[0]}${lastName[0]}`.toUpperCase()
+      : firstName
+        ? firstName[0].toUpperCase()
+        : (user?.email?.[0]?.toUpperCase() ?? "?");
+  const avatarUrl =
+    profile?.avatar_url ||
+    (meta.avatar_url as string | undefined) ||
+    (meta.picture as string | undefined) ||
+    null;
+
   return (
     <>
       <button
@@ -165,10 +190,24 @@ export default function HouseholdScopePopover() {
         type="button"
         onClick={handleToggle}
         aria-expanded={open}
-        aria-label={`Switch household. Current: ${activeHousehold?.name ?? "Personal"}`}
+        aria-label={`Switch scope. Current: ${activeHousehold?.name ?? "Personal"}`}
         className="relative flex h-11 w-11 items-center justify-center rounded-xl hover:bg-[var(--color-surface-alt)]/60 transition-colors cursor-pointer"
       >
-        <ScopeAvatar household={activeHousehold} size={28} />
+        {activeHousehold ? (
+          <HouseholdTile household={activeHousehold} size={28} />
+        ) : (
+          <span className="relative h-7 w-7 rounded-full bg-[var(--color-accent)] flex items-center justify-center text-[11px] font-semibold text-[var(--color-on-accent,white)] overflow-hidden">
+            {avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt={firstName || "Profile"}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              initials
+            )}
+          </span>
+        )}
       </button>
 
       {typeof document !== "undefined" && createPortal(popover, document.body)}

--- a/apps/finance/src/components/layout/SidebarMoreMenu.tsx
+++ b/apps/finance/src/components/layout/SidebarMoreMenu.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import clsx from "clsx";
-import { LuSparkles, LuHeadphones } from "react-icons/lu";
+import { LuEllipsis, LuSparkles, LuHeadphones } from "react-icons/lu";
 import { TbLogout } from "react-icons/tb";
 import { FaLock } from "react-icons/fa";
 import { ConfirmOverlay, Tooltip, TOOLTIP_SURFACE_CLASSES } from "@zervo/ui";
@@ -18,13 +18,15 @@ const POPOVER_WIDTH = 220;
 
 /**
  * Bottom-of-sidebar "..." menu. Anchored popover that opens to the right
- * of the trigger and contains user identity + secondary actions
- * (Upgrade, Help, Log out). The popover renders into document.body so
- * its position isn't constrained by the narrow floating sidebar.
+ * of the trigger and contains secondary actions (Upgrade, Help, Log
+ * out). User identity lives at the top of the sidebar in the scope
+ * popover; this menu is just the action drawer. The popover renders
+ * into document.body so its position isn't constrained by the narrow
+ * floating sidebar.
  */
 export default function SidebarMoreMenu() {
   const router = useRouter();
-  const { profile, user, logout } = useUser();
+  const { profile, logout } = useUser();
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ bottom: number; left: number } | null>(null);
   const [showUpgrade, setShowUpgrade] = useState(false);
@@ -33,37 +35,7 @@ export default function SidebarMoreMenu() {
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
-  const meta =
-    (user as unknown as { user_metadata?: Record<string, unknown> })
-      ?.user_metadata ?? {};
-  const firstName =
-    profile?.first_name || (meta.first_name as string | undefined) || "";
-  const lastName =
-    profile?.last_name || (meta.last_name as string | undefined) || "";
-  const rawName =
-    [firstName, lastName].filter(Boolean).join(" ") ||
-    (meta.name as string | undefined) ||
-    (meta.full_name as string | undefined) ||
-    "";
-  const fullName = rawName
-    ? rawName
-        .trim()
-        .split(/\s+/)
-        .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
-        .join(" ")
-    : user?.email || "";
   const tier = profile?.subscription_tier ?? "free";
-  const initials =
-    firstName && lastName
-      ? `${firstName[0]}${lastName[0]}`.toUpperCase()
-      : firstName
-        ? firstName[0].toUpperCase()
-        : (user?.email?.[0]?.toUpperCase() ?? "?");
-  const avatarUrl =
-    profile?.avatar_url ||
-    (meta.avatar_url as string | undefined) ||
-    (meta.picture as string | undefined) ||
-    null;
 
   useEffect(() => {
     if (!open) return;
@@ -137,32 +109,21 @@ export default function SidebarMoreMenu() {
 
   return (
     <>
-      <Tooltip content={fullName || "Account"} side="right">
+      <Tooltip content="More" side="right">
         <button
           ref={triggerRef}
           type="button"
           onClick={() => setOpen((v) => !v)}
-          aria-label="Account menu"
+          aria-label="More menu"
           aria-expanded={open}
           className={clsx(
-            "flex items-center justify-center w-10 h-10 rounded-full transition-shadow cursor-pointer",
-            "ring-offset-2 ring-offset-[var(--color-content-bg)]",
+            "flex items-center justify-center w-10 h-10 rounded-md transition-colors cursor-pointer",
             open
-              ? "ring-2 ring-[var(--color-fg)]/20"
-              : "hover:ring-2 hover:ring-[var(--color-fg)]/15",
+              ? "text-[var(--color-fg)] bg-[var(--color-fg)]/[0.08]"
+              : "text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-fg)]/[0.05]",
           )}
         >
-          <span className="relative h-8 w-8 rounded-full bg-[var(--color-accent)] flex items-center justify-center text-[11px] font-semibold text-[var(--color-on-accent,white)] overflow-hidden">
-            {avatarUrl ? (
-              <img
-                src={avatarUrl}
-                alt={fullName || "Account"}
-                className="h-full w-full object-cover"
-              />
-            ) : (
-              initials
-            )}
-          </span>
+          <LuEllipsis className="h-[18px] w-[18px]" />
         </button>
       </Tooltip>
 
@@ -189,14 +150,6 @@ export default function SidebarMoreMenu() {
                   "overflow-hidden",
                 )}
               >
-                <div className="px-4 pt-3 pb-2.5 border-b border-[var(--color-floating-border)]">
-                  <p className="text-[13px] font-medium text-[var(--color-floating-fg)] truncate leading-tight">
-                    {fullName || "User"}
-                  </p>
-                  <p className="text-[11px] text-[var(--color-floating-muted)] truncate leading-tight mt-0.5">
-                    {tier === "pro" ? "Pro" : "Free"}
-                  </p>
-                </div>
                 <div className="py-1.5">
                   {tier === "free" && (
                     <button


### PR DESCRIPTION
## Summary
Folds the redundant bottom user-avatar trigger into the top scope trigger and demotes the bottom slot to a generic actions menu.

- **Top trigger** now renders the user's own avatar (initials/photo) when in personal scope. In household scope it keeps the household tile so the trigger always reflects the active context. Clicking still opens the scope switcher (Personal / Households / Add household) — same popover, just a more identity-forward trigger.
- **Bottom trigger** flips back to a `…` icon. Its popover drops the user name/tier header (that lives at the top now) and only exposes secondary actions: Upgrade / Help / Log out.

## QA
Verified locally via Playwright at 1440×900 with `__qabypass=1`:
- `/dashboard`: top trigger renders the user-avatar circle, sidebar bbox unchanged (`x:12, y:12, w:56, h:876`), shadow + radius pill intact.
- Top popover opens to the right: shows "Add household" (test fixture has no households) — scope switcher path is alive.
- Bottom popover: trimmed to Upgrade / Help / Log out, no user header.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsdQbUcZMUZmrzyDQBR3tQ)_