### PR TITLE
Lift sidebar visually + fix slide-from-bottom highlight glitch

### DIFF
--- a/apps/finance/src/components/layout/SidebarContent.tsx
+++ b/apps/finance/src/components/layout/SidebarContent.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { motion } from "framer-motion";
 import clsx from "clsx";
 import { LuSettings } from "react-icons/lu";
 import { NAV_GROUPS, type NavItem } from "../nav";
@@ -10,6 +11,14 @@ import { isFeatureEnabled } from "../../lib/tierConfig";
 import { SidebarItem, Tooltip } from "@zervo/ui";
 import HouseholdScopePopover from "../households/HouseholdScopePopover";
 import SidebarMoreMenu from "./SidebarMoreMenu";
+
+// Each SidebarItem (icon-only mode): 18px icon + 8px vertical padding × 2 = 34px.
+// `space-y-0.5` (= 2px) inserts gap between rows, so each slot is 36px tall and
+// item N starts at y = N * 36 from the top of the <ul>. Hard-coding this is
+// cheap and makes the highlight position deterministic, which is the whole
+// reason the highlight lives at this level instead of inside SidebarItem.
+const ITEM_HEIGHT = 34;
+const ITEM_SLOT = 36;
 
 /** Subset of personal nav items that are meaningful in household scope. */
 const HOUSEHOLD_ALLOWED_HREFS = new Set(["/accounts", "/investments"]);
@@ -59,15 +68,35 @@ export default function SidebarContent({ onNavigate }: { onNavigate?: () => void
     : "/settings";
 
   const isItemActive = (itemHref: string) => pathname.startsWith(itemHref);
+  const activeIndex = items.findIndex((it) => isItemActive(it.href));
 
   return (
-    <div className="flex h-full w-full flex-col py-3 rounded-[20px] bg-[var(--color-content-bg)] shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_16px_rgba(0,0,0,0.04)]">
+    <div className="flex h-full w-full flex-col py-3 rounded-[20px] bg-[var(--color-floating-bg)] border border-[color-mix(in_oklab,var(--color-fg),transparent_92%)] shadow-[0_12px_32px_-8px_rgba(0,0,0,0.12),0_4px_12px_-3px_rgba(0,0,0,0.06)]">
       <div className="flex justify-center pb-2">
         <HouseholdScopePopover />
       </div>
 
       <nav className="flex-1 overflow-y-auto scrollbar-thin px-2 pt-1">
-        <ul className="space-y-0.5">
+        <ul className="relative space-y-0.5">
+          {/* Single persistent highlight overlay. Position is driven by
+              `activeIndex` so the indicator slides smoothly between rows
+              without relying on framer-motion's layoutId tracking — that
+              tracking occasionally lost its previous position when the
+              old item's motion span unmounted, causing the highlight to
+              fly in from the bottom of the list. */}
+          {activeIndex >= 0 && (
+            <motion.div
+              aria-hidden
+              className="pointer-events-none absolute left-0 right-0 top-0"
+              style={{ height: ITEM_HEIGHT }}
+              initial={false}
+              animate={{ y: activeIndex * ITEM_SLOT }}
+              transition={{ type: "spring", stiffness: 420, damping: 36 }}
+            >
+              <span className="absolute inset-0 bg-[var(--color-fg)]/[0.08]" />
+              <span className="absolute left-0 top-1 bottom-1 w-[3px] rounded-r-full bg-[var(--color-fg)]" />
+            </motion.div>
+          )}
           {items.map((it) => (
             <SidebarItem
               key={it.href}
@@ -77,6 +106,7 @@ export default function SidebarContent({ onNavigate }: { onNavigate?: () => void
               active={isItemActive(it.href)}
               disabled={it.disabled}
               isCollapsed
+              externalActiveHighlight
               onClick={onNavigate}
             />
           ))}

--- a/packages/ui/src/SidebarItem.tsx
+++ b/packages/ui/src/SidebarItem.tsx
@@ -16,6 +16,17 @@ interface SidebarItemProps {
   isCollapsed?: boolean;
   notification?: boolean;
   onClick?: () => void;
+  /**
+   * When true, suppresses the per-item layoutId-based active highlight.
+   * The consumer is expected to render its own highlight element (e.g.
+   * a single position-animated overlay) so the active indicator survives
+   * navigation without relying on framer-motion's shared-layout
+   * tracking — that tracking occasionally loses its position cache when
+   * SidebarItems unmount and remount, causing the highlight to slide in
+   * from the bottom of the list. Active text color + font weight still
+   * apply.
+   */
+  externalActiveHighlight?: boolean;
 }
 
 export default function SidebarItem({
@@ -27,6 +38,7 @@ export default function SidebarItem({
   isCollapsed = false,
   notification = false,
   onClick,
+  externalActiveHighlight = false,
 }: SidebarItemProps) {
   const item = (
     <li>
@@ -53,8 +65,10 @@ export default function SidebarItem({
             carry a layoutId so framer-motion animates them between
             sidebar items as the user navigates — the highlight
             "slides" from the previously-active row to the new one
-            (Discord-style), instead of disappearing/reappearing. */}
-        {active && (
+            (Discord-style), instead of disappearing/reappearing.
+            When `externalActiveHighlight` is true, the consumer
+            renders the highlight itself and we skip these spans. */}
+        {active && !externalActiveHighlight && (
           <>
             <motion.span
               layoutId="sidebar-active-bg"


### PR DESCRIPTION
## Summary
Two unrelated fixes that landed in the same pass.

### 1. The sidebar didn't read as floating — especially in dark mode
Bg was `--color-content-bg` and shadow was tiny. Light mode had no color difference and a too-subtle shadow; dark mode had no separation at all because dark-on-dark shadows barely render.

Fix: switch the sidebar bg to `--color-floating-bg`. In light mode that's still white (= content), so a stronger drop shadow does the work. In dark mode it's `#27272a` against `#050505` content, so the color difference does the work. Hairline border added for crispness in both modes.

```
bg:     var(--color-floating-bg)
border: 1px solid color-mix(in oklab, var(--color-fg), transparent 92%)
shadow: 0 12px 32px -8px rgba(0,0,0,.12),
        0 4px 12px -3px rgba(0,0,0,.06)
radius: 20px
```

### 2. Active highlight occasionally slid in from the bottom of the nav
Cause: the highlight lived inside each `SidebarItem` as two `motion.span`s with shared `layoutId`s. When the previously-active item unmounted its spans and the newly-active item mounted its own, framer-motion's layoutId tracking sometimes lost the prior position cache and re-anchored the new mount to `(0, ulHeight)` — so the spring animated in from the very bottom of the list.

Fix: lift the highlight out of `SidebarItem` into a single persistent `motion.div` in `SidebarContent` that animates `y` based on `activeIndex × 36px`. No mount/unmount. No shared-layout tracking. The slide is now fully deterministic.

Added an `externalActiveHighlight` opt-in to the `@zervo/ui` `SidebarItem` so the admin app — which still uses the per-item layoutId animation in its full-width sidebar — keeps its current behavior unchanged.

## QA
Verified locally via Playwright at 1440×900 with `__qabypass=1`:
- **Light mode** (`/dashboard`): clear drop shadow defines the pill against the white page.
- **Dark mode** (`/dashboard`): bg color shift makes the lift unambiguous.
- **Animation sweep** through `/dashboard → /agent → /accounts → /transactions → /budgets → /investments → /dashboard`: highlight lands on the correct icon every time, animates between adjacent rows.
- `pnpm typecheck && pnpm lint` clean for finance and admin.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsdQbUcZMUZmrzyDQBR3tQ)_