### PR TITLE
Polish sidebar visuals + round donut slices + close stuck tooltips

### DIFF
--- a/apps/finance/src/components/dashboard/TopCategoriesCard.tsx
+++ b/apps/finance/src/components/dashboard/TopCategoriesCard.tsx
@@ -212,7 +212,7 @@ function InteractiveDonut({ segments, total, rangeLabel, hoveredId, onHover, onC
               strokeWidth={isHovered ? DONUT_STROKE + 4 : DONUT_STROKE}
               strokeDasharray={seg.dashArray}
               strokeDashoffset={seg.dashOffset}
-              strokeLinecap="butt"
+              strokeLinecap="round"
               style={{
                 opacity: dimmed ? 0.4 : 1,
                 cursor: "pointer",

--- a/apps/finance/src/components/layout/SidebarContent.tsx
+++ b/apps/finance/src/components/layout/SidebarContent.tsx
@@ -19,6 +19,12 @@ import SidebarMoreMenu from "./SidebarMoreMenu";
 // reason the highlight lives at this level instead of inside SidebarItem.
 const ITEM_HEIGHT = 34;
 const ITEM_SLOT = 36;
+// Distance from the sidebar pill's top to the first nav item's top, summed
+// from the chrome above the nav: py-3 (12px) + scope avatar h-11 (44px) +
+// pb-2 (8px) + nav pt-1 (4px) = 68px. The accent bar floats at this offset
+// (relative to the pill, not the nav) so it can sit flush against the
+// pill's left edge without being clipped by nav's overflow.
+const NAV_TOP_OFFSET = 68;
 
 /** Subset of personal nav items that are meaningful in household scope. */
 const HOUSEHOLD_ALLOWED_HREFS = new Set(["/accounts", "/investments"]);
@@ -71,32 +77,28 @@ export default function SidebarContent({ onNavigate }: { onNavigate?: () => void
   const activeIndex = items.findIndex((it) => isItemActive(it.href));
 
   return (
-    <div className="flex h-full w-full flex-col py-3 rounded-[20px] bg-[var(--color-floating-bg)] border border-[color-mix(in_oklab,var(--color-fg),transparent_92%)] shadow-[0_12px_32px_-8px_rgba(0,0,0,0.12),0_4px_12px_-3px_rgba(0,0,0,0.06)]">
+    <div className="relative flex h-full w-full flex-col py-3 rounded-[20px] bg-[var(--color-bg)] shadow-[0_12px_32px_-8px_rgba(0,0,0,0.12),0_4px_12px_-3px_rgba(0,0,0,0.06)]">
+      {/* Active accent bar — pinned to the sidebar pill's left edge,
+          sits outside `nav` so it isn't clipped by overflow and so it
+          can sit flush against the pill instead of inset by nav's
+          horizontal padding. */}
+      {activeIndex >= 0 && (
+        <motion.span
+          aria-hidden
+          className="pointer-events-none absolute left-0 w-[3px] bg-[var(--color-fg)]"
+          style={{ height: ITEM_HEIGHT, top: 0 }}
+          initial={false}
+          animate={{ y: NAV_TOP_OFFSET + activeIndex * ITEM_SLOT }}
+          transition={{ type: "spring", stiffness: 420, damping: 36 }}
+        />
+      )}
+
       <div className="flex justify-center pb-2">
         <HouseholdScopePopover />
       </div>
 
       <nav className="flex-1 overflow-y-auto scrollbar-thin px-2 pt-1">
-        <ul className="relative space-y-0.5">
-          {/* Single persistent highlight overlay. Position is driven by
-              `activeIndex` so the indicator slides smoothly between rows
-              without relying on framer-motion's layoutId tracking — that
-              tracking occasionally lost its previous position when the
-              old item's motion span unmounted, causing the highlight to
-              fly in from the bottom of the list. */}
-          {activeIndex >= 0 && (
-            <motion.div
-              aria-hidden
-              className="pointer-events-none absolute left-0 right-0 top-0"
-              style={{ height: ITEM_HEIGHT }}
-              initial={false}
-              animate={{ y: activeIndex * ITEM_SLOT }}
-              transition={{ type: "spring", stiffness: 420, damping: 36 }}
-            >
-              <span className="absolute inset-0 bg-[var(--color-fg)]/[0.08]" />
-              <span className="absolute left-0 top-1 bottom-1 w-[3px] rounded-r-full bg-[var(--color-fg)]" />
-            </motion.div>
-          )}
+        <ul className="space-y-0.5">
           {items.map((it) => (
             <SidebarItem
               key={it.href}

--- a/packages/ui/src/Tooltip.tsx
+++ b/packages/ui/src/Tooltip.tsx
@@ -99,6 +99,31 @@ export default function Tooltip({ content, children, side = "top", delay = 120 }
 
   useEffect(() => () => cancelTimer(), []);
 
+  // When the user alt-tabs out of the window (or the cursor leaves the
+  // document entirely) `mouseleave` doesn't always fire on the trigger,
+  // and the tooltip stays visible after they return — even though the
+  // pointer is nowhere near the trigger. Listen for window blur and
+  // doc-level mouseleave and force-close so the tooltip can't get
+  // stuck.
+  useEffect(() => {
+    if (!open && timeoutRef.current === null) return;
+    const handleAway = () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      setOpen(false);
+    };
+    window.addEventListener("blur", handleAway);
+    document.addEventListener("mouseleave", handleAway);
+    document.addEventListener("visibilitychange", handleAway);
+    return () => {
+      window.removeEventListener("blur", handleAway);
+      document.removeEventListener("mouseleave", handleAway);
+      document.removeEventListener("visibilitychange", handleAway);
+    };
+  }, [open]);
+
   if (!content) return children;
 
   // Clone the child to attach hover/focus listeners and the ref.


### PR DESCRIPTION
## Summary
Four targeted fixes:

### Sidebar dark mode was wayyyy too light
Bg moves from `--color-floating-bg` (`#27272a` in dark — bright zinc-800) to `--color-bg` (`#0d0d0d` — subtle ~8-luminance step up from the `#050505` content bg). Light mode is unchanged: both vars resolve to `#ffffff`.

### Drop the sidebar border
Shadow defines the pill in light mode. The subtle bg shift defines it in dark mode. The hairline border was redundant in both.

### Active tab: no bg fill, accent flush-left and square-cornered
- No more translucent fg overlay on the active row.
- The accent bar lifts out of `<nav>` (so `nav`'s `px-2` no longer insets it) into the sidebar pill itself, animating `y` against a `NAV_TOP_OFFSET` constant.
- Square corners (no `rounded-r-full`).
- Full item height (34px), no `top-1 bottom-1` inset — clean rectangle.

### Spending donut: slightly rounded slices
`strokeLinecap` flips from `butt` to `round` on the segments in `TopCategoriesCard` — pill-shaped slice ends without re-architecting the SVG.

### Tooltip persisted after alt-tab
When the window loses focus, `mouseleave` doesn't reliably fire on the trigger, so the tooltip would stay visible after the user came back even with no cursor on it. While a tooltip is open, listen for `window blur`, `document mouseleave`, and `visibilitychange` and force-close on any of them.

## Test plan
Per the request, no QA — merging directly.

- [x] `pnpm typecheck` (finance + admin)
- [x] `pnpm lint` (finance)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsdQbUcZMUZmrzyDQBR3tQ)_