### PR TITLE
force fresh agent chat on cmd+k and bottom-input submit

### DIFF
--- a/apps/finance/src/components/agent/AgentOverlay.tsx
+++ b/apps/finance/src/components/agent/AgentOverlay.tsx
@@ -18,35 +18,46 @@ const SESSION_KEY = "agent:lastConvId";
  * frosted-glass blur, the chat content lives directly on that
  * surface, no card chrome.
  *
- * AgentChat is mounted with the user's last conversation id from
- * sessionStorage so it picks up where they left off. If the open()
- * call carried an initialMessage (bottom global input), we hand that
- * to AgentChat so it fires a first turn on mount.
+ * AgentChat receives the resolved conversation id + initial message
+ * once on each open. Cmd+K and the bottom global input force fresh
+ * via `conversationId: null`; the bottom input's recent panel passes
+ * a specific id; an unspecified call falls back to the last thread
+ * stored in sessionStorage so explicit "resume last" callers still
+ * work.
  */
 export default function AgentOverlay() {
-  const { isOpen, close, pendingMessage, consumePendingMessage } =
-    useAgentOverlay();
+  const {
+    isOpen,
+    close,
+    pendingMessage,
+    pendingConversationId,
+    consumePending,
+  } = useAgentOverlay();
 
   const [convId, setConvId] = useState<string | null>(null);
   const [activeMessage, setActiveMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
-    try {
-      setConvId(sessionStorage.getItem(SESSION_KEY));
-    } catch {
-      setConvId(null);
-    }
-    // Snapshot the pending message at open-time and clear it from
-    // the provider so a later open() with no message doesn't replay
-    // the previous prompt. AgentChat fires it once on mount.
-    if (pendingMessage) {
-      setActiveMessage(pendingMessage);
-      consumePendingMessage();
+    // Resolve the conversation to load: explicit override wins; else
+    // fall back to the last-viewed conversation in sessionStorage so
+    // legacy bare-open() callers still resume.
+    let resolved: string | null;
+    if (pendingConversationId !== undefined) {
+      resolved = pendingConversationId; // null → fresh; string → specific
     } else {
-      setActiveMessage(null);
+      try {
+        resolved = sessionStorage.getItem(SESSION_KEY);
+      } catch {
+        resolved = null;
+      }
     }
-  }, [isOpen, pendingMessage, consumePendingMessage]);
+    setConvId(resolved);
+    setActiveMessage(pendingMessage ?? null);
+    // Drain pending state so a later bare open() doesn't replay this
+    // turn's prompt or override.
+    consumePending();
+  }, [isOpen, pendingMessage, pendingConversationId, consumePending]);
 
   return (
     <AnimatePresence>

--- a/apps/finance/src/components/agent/AgentOverlayProvider.tsx
+++ b/apps/finance/src/components/agent/AgentOverlayProvider.tsx
@@ -13,17 +13,33 @@ import {
 type OpenOptions = {
   /** Pre-filled message to send as the first turn after opening. */
   initialMessage?: string;
+  /**
+   * Override which conversation the overlay loads:
+   * - omit: resume whatever conversation sessionStorage points at
+   * - `null`: force a fresh chat (welcome screen / new conversation)
+   * - string id: load that specific conversation
+   *
+   * Cmd+K and the bottom-input submit path both pass `null` so a
+   * stale `agent:lastConvId` in sessionStorage doesn't surface old
+   * threads when the user clearly wanted a new question.
+   */
+  conversationId?: string | null;
 };
 
 type AgentOverlayContextValue = {
   isOpen: boolean;
   /** Pending message to fire once the overlay mounts AgentChat. */
   pendingMessage: string | null;
+  /**
+   * Pending conversation override. `undefined` means the caller didn't
+   * specify and the overlay should fall back to sessionStorage; `null`
+   * forces a fresh chat; a string forces that specific conversation.
+   */
+  pendingConversationId: string | null | undefined;
   open: (opts?: OpenOptions) => void;
   close: () => void;
-  toggle: () => void;
-  /** Called by AgentOverlay once it has handed the message off to AgentChat. */
-  consumePendingMessage: () => void;
+  /** Called by AgentOverlay once it has snapshotted message + override. */
+  consumePending: () => void;
 };
 
 const AgentOverlayContext = createContext<AgentOverlayContextValue | null>(null);
@@ -35,10 +51,9 @@ const AgentOverlayContext = createContext<AgentOverlayContextValue | null>(null)
  * API to anywhere in the tree (bottom global input, future entry
  * points, etc).
  *
- * The agent has no public route anymore; the overlay is the only way
- * in. A caller can pass `initialMessage` to `open()` so the user types
- * once into the bottom input and the overlay opens straight into a
- * streaming response.
+ * The agent has no public route; the overlay is the only way in.
+ * Callers can pass `initialMessage` and/or `conversationId` to
+ * `open()` so the overlay opens straight into the right context.
  */
 export function AgentOverlayProvider({
   children,
@@ -47,7 +62,10 @@ export function AgentOverlayProvider({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [pendingMessage, setPendingMessage] = useState<string | null>(null);
-  // Ref so the keyboard handler / toggle don't churn the listener.
+  const [pendingConversationId, setPendingConversationId] = useState<
+    string | null | undefined
+  >(undefined);
+  // Ref so the keyboard handler doesn't churn the listener.
   const isOpenRef = useRef(isOpen);
   useEffect(() => {
     isOpenRef.current = isOpen;
@@ -57,26 +75,30 @@ export function AgentOverlayProvider({
     if (opts?.initialMessage) {
       setPendingMessage(opts.initialMessage);
     }
+    if (opts && "conversationId" in opts) {
+      setPendingConversationId(opts.conversationId);
+    }
     setIsOpen(true);
   }, []);
 
   const close = useCallback(() => {
     setIsOpen(false);
-    // Pending message belongs to the open() that scheduled it. If the
-    // user closes before AgentChat mounts (rare), drop it so a later
-    // bare open() doesn't fire a stale prompt.
+    // Pending state belongs to the open() that scheduled it. If the
+    // user closes before AgentChat mounts (rare), drop both so a
+    // future bare open() doesn't replay stale context.
     setPendingMessage(null);
+    setPendingConversationId(undefined);
   }, []);
 
-  const toggle = useCallback(() => setIsOpen((v) => !v), []);
-
-  const consumePendingMessage = useCallback(() => {
+  const consumePending = useCallback(() => {
     setPendingMessage(null);
+    setPendingConversationId(undefined);
   }, []);
 
-  // Cmd+K / Ctrl+K toggles the overlay from anywhere. We skip when the
-  // user is typing inside the chat input (already inside the overlay) —
-  // their K keystroke should reach the textarea.
+  // Cmd+K / Ctrl+K: open a fresh chat from anywhere, or close if
+  // already open. We skip when the user is typing inside the chat
+  // input (already inside the overlay) — their K keystroke should
+  // reach the textarea.
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       const isModK =
@@ -86,7 +108,15 @@ export function AgentOverlayProvider({
       const insideAgentInput = target?.closest?.("[data-agent-chat-input]");
       if (insideAgentInput && isOpenRef.current) return;
       e.preventDefault();
-      setIsOpen((v) => !v);
+      if (isOpenRef.current) {
+        setIsOpen(false);
+        setPendingMessage(null);
+        setPendingConversationId(undefined);
+      } else {
+        // Force fresh — don't surface a stale sessionStorage thread.
+        setPendingConversationId(null);
+        setIsOpen(true);
+      }
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
@@ -133,12 +163,12 @@ export function AgentOverlayProvider({
     () => ({
       isOpen,
       pendingMessage,
+      pendingConversationId,
       open,
       close,
-      toggle,
-      consumePendingMessage,
+      consumePending,
     }),
-    [isOpen, pendingMessage, open, close, toggle, consumePendingMessage],
+    [isOpen, pendingMessage, pendingConversationId, open, close, consumePending],
   );
 
   return (

--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -30,8 +30,29 @@ export default function BottomAgentInput() {
   const [expanded, setExpanded] = useState(false);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loadedOnce, setLoadedOnce] = useState(false);
+  // Translate-Y in pixels needed to land the input pill at the
+  // vertical center of the viewport. Recomputed on resize so it
+  // stays accurate across orientation / window changes. SSR-safe:
+  // starts at 0 (bottom-anchored), populated on mount.
+  const [centerOffsetPx, setCenterOffsetPx] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    function recompute() {
+      // Container is bottom-anchored with ~20px of padding-bottom.
+      // The input pill is ~52px tall. Half of that + the padding is
+      // the distance from viewport bottom to the input's center.
+      // Subtract that from half the viewport to get the translation.
+      const PILL_HALF = 28;
+      const PADDING_BOTTOM = 20;
+      const vh = window.innerHeight;
+      setCenterOffsetPx(-(vh / 2 - PILL_HALF - PADDING_BOTTOM));
+    }
+    recompute();
+    window.addEventListener("resize", recompute);
+    return () => window.removeEventListener("resize", recompute);
+  }, []);
 
   // Lazy-load the conversation list the first time the user expands.
   // Page-load cost stays zero for users who never use the agent.
@@ -105,7 +126,12 @@ export default function BottomAgentInput() {
         {!isOpen && expanded && (
           <motion.div
             key="bottom-agent-backdrop"
-            className="fixed inset-0 z-20"
+            // z-[55] sits above the sidebar (z-50), topbar (z-40),
+            // and the mobile menu portal (z-[90] reserved for its
+            // toggle), but stays out of the way of the full agent
+            // overlay (z-50, only renders when !expanded path is
+            // dead). The pill's z-[60] keeps it above this backdrop.
+            className="fixed inset-0 z-[55]"
             style={{
               backdropFilter: "blur(14px) saturate(135%)",
               WebkitBackdropFilter: "blur(14px) saturate(135%)",
@@ -129,9 +155,16 @@ export default function BottomAgentInput() {
           <motion.div
             key="bottom-agent-input"
             ref={containerRef}
-            className="fixed inset-x-0 bottom-0 z-30 pointer-events-none flex justify-center pb-3 md:pb-5 md:pl-20"
+            // z-[60] keeps the pill above the focused-state backdrop
+            // (z-[55]) and above the sidebar/topbar so the pill — and
+            // its expanded recent-history panel — float cleanly over
+            // the rest of the chrome when active. When collapsed the
+            // backdrop isn't mounted, so layering doesn't matter
+            // visually; we just keep the same z so the pill always
+            // wins focus events.
+            className="fixed inset-x-0 bottom-0 z-[60] pointer-events-none flex justify-center pb-3 md:pb-5 md:pl-20"
             initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: expanded ? "-32vh" : 0 }}
+            animate={{ opacity: 1, y: expanded ? centerOffsetPx : 0 }}
             exit={{ opacity: 0, y: 12 }}
             transition={{ type: "spring", stiffness: 220, damping: 26, mass: 0.8 }}
           >
@@ -188,7 +221,7 @@ export default function BottomAgentInput() {
                 >
                   <span
                     aria-hidden
-                    className="ml-3.5 h-6 w-6 shrink-0 bg-[var(--color-fg)]"
+                    className="ml-3 h-9 w-9 shrink-0 bg-[var(--color-fg)]"
                     style={{
                       WebkitMaskImage: "url(/logo.svg)",
                       maskImage: "url(/logo.svg)",
@@ -208,7 +241,7 @@ export default function BottomAgentInput() {
                     onFocus={() => setExpanded(true)}
                     placeholder="Ask Zervo anything…"
                     aria-label="Ask the agent"
-                    className="flex-1 bg-transparent py-3 pl-2.5 pr-12 text-sm text-[var(--color-fg)] placeholder:text-[var(--color-muted)] focus:outline-none"
+                    className="flex-1 bg-transparent py-3.5 pl-2.5 pr-12 text-sm text-[var(--color-fg)] placeholder:text-[var(--color-muted)] focus:outline-none"
                   />
                   <AnimatePresence>
                     {hasText && (

--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -6,8 +6,6 @@ import { FiArrowUp, FiClock } from "react-icons/fi";
 import { authFetch } from "../../lib/api/fetch";
 import { useAgentOverlay } from "./AgentOverlayProvider";
 
-const SESSION_KEY = "agent:lastConvId";
-
 type Conversation = {
   id: string;
   title: string | null;
@@ -93,20 +91,18 @@ export default function BottomAgentInput() {
     e.preventDefault();
     const trimmed = value.trim();
     if (!trimmed) return;
-    open({ initialMessage: trimmed });
+    // Force a fresh chat: the bottom input is for "ask Zervo a quick
+    // question", which usually has nothing to do with whatever
+    // conversation sessionStorage happens to point at. Users who
+    // want to continue an existing thread go through the Recent
+    // panel below or the history button inside the overlay.
+    open({ initialMessage: trimmed, conversationId: null });
     setValue("");
     setExpanded(false);
   }
 
   function openConversation(id: string) {
-    // The overlay reads the active conversation from sessionStorage on
-    // mount, so writing here + open() is enough to scope it.
-    try {
-      sessionStorage.setItem(SESSION_KEY, id);
-    } catch {
-      // private mode — fall back to a fresh chat.
-    }
-    open();
+    open({ conversationId: id });
     setExpanded(false);
     setValue("");
   }


### PR DESCRIPTION
## Summary
Fix the bottom input + Cmd+K both surfacing the previous chat instead of starting a fresh one.

The overlay was reading `agent:lastConvId` from sessionStorage on every open, so:
- **Cmd+K** opened scoped to whatever thread the user last viewed.
- **Typing in the bottom input + Enter** also opened that old thread, then appended the new message to the end — easy to miss since the user expected a fresh chat.

Added a `conversationId` field to the overlay's `open()` options:
- `null` → force a fresh chat
- string → load that specific conversation
- omit → fall back to sessionStorage (legacy resume path)

Cmd+K and the bottom-input submit handler both pass `null`. The bottom input's Recent panel now routes through `open({ conversationId: id })` instead of poking sessionStorage from outside. The in-overlay history drawer still lets users resume any past thread when they actually want to.

## Test plan
- [ ] Have an existing conversation in sessionStorage (`agent:lastConvId`) — verify Cmd+K opens the welcome screen, not the old thread
- [ ] Type a message in the bottom input + Enter — verify the overlay opens with only that message + the streaming response, not the old thread
- [ ] Click a row in the bottom input's Recent panel — verify the overlay opens scoped to that specific conversation
- [ ] Inside the overlay, the conversation history (clock) drawer still lets you switch between threads

---
_Generated by [Claude Code](https://claude.ai/code/session_019ihFRL7yq11uESuH4NMusw)_