### PR TITLE
drop redundant recent panel + clock per row, float drawers

### DIFF
--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -46,6 +46,7 @@ export default function BottomAgentInput() {
   const [expanded, setExpanded] = useState(false);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loadedOnce, setLoadedOnce] = useState(false);
+  const [loadingConversations, setLoadingConversations] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   // Translate-Y in pixels needed to land the input pill at the
   // vertical center of the viewport. Recomputed on resize so it
@@ -79,11 +80,16 @@ export default function BottomAgentInput() {
     return () => window.removeEventListener("resize", recompute);
   }, []);
 
-  // Lazy-load the conversation list the first time the user expands.
-  // Page-load cost stays zero for users who never use the agent.
+  // Lazy-load the conversation list. We fire on first expand AND on
+  // every drawer open: first expand keeps page-load cost at zero for
+  // users who never touch the agent; the drawer open path is a refresh
+  // so a thread the user just had in the overlay shows up here without
+  // a full page reload, and recovers from a previous failed fetch.
   useEffect(() => {
-    if (!expanded || loadedOnce) return;
+    if (!expanded && !drawerOpen) return;
+    if (loadedOnce && !drawerOpen) return;
     setLoadedOnce(true);
+    setLoadingConversations(true);
     let cancelled = false;
     (async () => {
       try {
@@ -93,12 +99,14 @@ export default function BottomAgentInput() {
         if (!cancelled) setConversations(body.conversations ?? []);
       } catch {
         // Silent — input still works without history visible.
+      } finally {
+        if (!cancelled) setLoadingConversations(false);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [expanded, loadedOnce]);
+  }, [expanded, drawerOpen, loadedOnce]);
 
   // Click outside collapses. Paused while the drawer is open — the
   // drawer renders via portal at body level, so its clicks count as
@@ -115,6 +123,23 @@ export default function BottomAgentInput() {
     }
     document.addEventListener("mousedown", onDocClick);
     return () => document.removeEventListener("mousedown", onDocClick);
+  }, [expanded, drawerOpen]);
+
+  // Esc collapses the focused state. Gated on `!drawerOpen` so when
+  // both are up Esc closes the drawer first (its own listener handles
+  // that) and a second Esc collapses the input — same one-thing-at-a-
+  // time pattern as a stack of modals.
+  useEffect(() => {
+    if (!expanded || drawerOpen) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      setExpanded(false);
+      setValue("");
+      inputRef.current?.blur();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
   }, [expanded, drawerOpen]);
 
   function handleSubmit(e: FormEvent) {
@@ -190,9 +215,9 @@ export default function BottomAgentInput() {
               exit={{ opacity: 0, x: -8, scale: 0.95 }}
               transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
               aria-label="Conversation history"
-              className="fixed top-4 left-4 z-[60] inline-flex items-center justify-center h-10 w-10 rounded-full bg-[var(--color-surface-alt)] text-[var(--color-fg)] shadow-[0_8px_24px_-12px_rgba(0,0,0,0.4),0_2px_6px_-3px_rgba(0,0,0,0.2)] hover:scale-105 transition-transform"
+              className="fixed top-4 left-4 z-[60] inline-flex items-center justify-center h-9 w-9 rounded-full text-[var(--color-muted)] hover:text-[var(--color-fg)] transition-colors"
             >
-              <FiClock className="h-4 w-4" />
+              <FiClock className="h-[18px] w-[18px]" />
             </motion.button>
           )}
         </AnimatePresence>
@@ -204,7 +229,11 @@ export default function BottomAgentInput() {
           size="sm"
           side="left"
         >
-          {conversations.length === 0 ? (
+          {loadingConversations && conversations.length === 0 ? (
+            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
+              Loading…
+            </div>
+          ) : conversations.length === 0 ? (
             <div className="text-xs text-[var(--color-muted)] py-6 text-center">
               No past conversations.
             </div>

--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -164,7 +164,6 @@ export default function BottomAgentInput() {
   }
 
   const hasText = value.trim().length > 0;
-  const visibleConversations = conversations.slice(0, 6);
 
   return (
     <>
@@ -244,18 +243,15 @@ export default function BottomAgentInput() {
                   key={c.id}
                   type="button"
                   onClick={() => openConversation(c.id)}
-                  className="w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-left hover:bg-[var(--color-surface-alt)]/60 transition-colors"
+                  className="w-full flex flex-col items-start px-2 py-2 rounded-md text-left hover:bg-[var(--color-surface-alt)]/60 transition-colors"
                 >
-                  <FiClock className="h-3.5 w-3.5 text-[var(--color-muted)] shrink-0" />
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm text-[var(--color-fg)] truncate">
-                      {c.title?.trim() || "Untitled"}
-                    </div>
-                    <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
-                      {nowAtMount !== null
-                        ? formatRelative(c.last_message_at, nowAtMount)
-                        : ""}
-                    </div>
+                  <div className="text-sm text-[var(--color-fg)] truncate w-full">
+                    {c.title?.trim() || "Untitled"}
+                  </div>
+                  <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
+                    {nowAtMount !== null
+                      ? formatRelative(c.last_message_at, nowAtMount)
+                      : ""}
                   </div>
                 </button>
               ))}
@@ -280,45 +276,6 @@ export default function BottomAgentInput() {
             transition={{ type: "spring", stiffness: 220, damping: 26, mass: 0.8 }}
           >
             <div className="pointer-events-auto w-full max-w-[640px] mx-3 md:mx-4 flex flex-col">
-              <AnimatePresence>
-                {expanded && visibleConversations.length > 0 && (
-                  <motion.div
-                    key="history"
-                    initial={{ opacity: 0, y: 8 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 8 }}
-                    transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
-                    className="mb-3"
-                  >
-                    <div className="rounded-3xl bg-[var(--color-surface-alt)] shadow-[0_24px_60px_-30px_rgba(0,0,0,0.5)] p-2">
-                      <div className="px-3 py-1.5 text-[11px] uppercase tracking-[0.12em] text-[var(--color-muted)]">
-                        Recent
-                      </div>
-                      <div className="max-h-[36vh] overflow-y-auto">
-                        {visibleConversations.map((c) => (
-                          <button
-                            key={c.id}
-                            type="button"
-                            onMouseDown={(e) => {
-                              // Stop the click-outside / blur path so the
-                              // following click event still fires.
-                              e.preventDefault();
-                            }}
-                            onClick={() => openConversation(c.id)}
-                            className="w-full flex items-center gap-2.5 px-3 py-2 rounded-xl text-left text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface)]/70 transition-colors"
-                          >
-                            <FiClock className="h-3.5 w-3.5 text-[var(--color-muted)] shrink-0" />
-                            <span className="truncate">
-                              {c.title?.trim() || "Untitled"}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-
               <form onSubmit={handleSubmit}>
                 <motion.div
                   animate={{

--- a/packages/ui/src/Drawer.tsx
+++ b/packages/ui/src/Drawer.tsx
@@ -147,6 +147,10 @@ export default function Drawer({
         <motion.div
           className={clsx(
             "fixed inset-0 z-[80] flex overflow-hidden overscroll-contain items-stretch justify-stretch",
+            // Desktop: pad the viewport so the panel floats away from
+            // every edge instead of sitting flush. Mobile keeps the
+            // edge-to-edge behavior so the dialog has full ergonomics.
+            "sm:p-3",
             side === "left" ? "sm:justify-start" : "sm:justify-end",
           )}
           initial={{ opacity: 0 }}
@@ -170,6 +174,10 @@ export default function Drawer({
             aria-modal="true"
             className={clsx(
               "relative z-10 w-full h-full bg-[var(--color-content-bg)] flex flex-col rounded-none overflow-hidden",
+              // Floating look on desktop: rounded all the way around
+              // and a soft shadow to separate the panel from the
+              // dimmed page behind it. Mobile stays edge-to-edge.
+              "sm:rounded-2xl sm:shadow-[0_30px_80px_-30px_rgba(0,0,0,0.5),0_8px_24px_-12px_rgba(0,0,0,0.25)]",
               // Width constraints only apply from small screens up.
               size === "sm" && "sm:max-w-sm",
               size === "md" && "sm:max-w-md",


### PR DESCRIPTION
## Summary
- **Drop the inline Recent panel** above the focused bottom input. The top-left clock now opens a drawer with the full list, so the inline copy was duplicate + busy.
- **Drop the per-row clock** in the history drawer. The drawer *is* the conversation history; a clock-per-row is noise. Title + timestamp only.
- **Float every Drawer** on desktop: 12px viewport padding, fully rounded corners, and a soft drop shadow so the panel reads as a card sitting on the dimmed backdrop — same vibe as the sidebar floating off the left edge. Mobile stays edge-to-edge for ergonomics.

## Test plan
- [ ] Focus the bottom input — no Recent panel above the pill anymore
- [ ] Open the conversation history drawer — rows show title + timestamp, no leading icon
- [ ] All right-side drawers across the app (transactions, accounts, budgets, etc.) float with rounded corners and a margin from every edge on desktop
- [ ] Mobile drawers still take over the full viewport
- [ ] Drawer slide-in animation still feels right with the new floating layout

---
_Generated by [Claude Code](https://claude.ai/code/session_019ihFRL7yq11uESuH4NMusw)_