### PR TITLE
extract shared AgentHistoryDrawer + dock both history drawers left

### DIFF
--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -9,15 +9,15 @@ import {
   type FormEvent,
 } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { FiArrowUp, FiPlus, FiClock, FiTrash2 } from "react-icons/fi";
+import { FiArrowUp, FiClock } from "react-icons/fi";
 import { marked } from "marked";
-import { Drawer, ConfirmOverlay } from "@zervo/ui";
 import { authFetch } from "../../lib/api/fetch";
 import { useUser } from "../providers/UserProvider";
 import ToolWidget, {
   type ToolBlock as ToolBlockData,
 } from "./widgets/ToolWidget";
 import { AnimateProvider } from "./widgets/primitives";
+import AgentHistoryDrawer from "./AgentHistoryDrawer";
 
 // sessionStorage key remembering the last conversation id viewed in
 // this browser tab. New tabs / new devices have an empty session, so
@@ -99,18 +99,6 @@ function greeting(hour: number): string {
   if (hour < 12) return "Good morning";
   if (hour < 18) return "Good afternoon";
   return "Good evening";
-}
-
-function formatRelative(iso: string, now: number): string {
-  const ts = new Date(iso).getTime();
-  const diffMin = Math.floor((now - ts) / 60_000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 function formatMessageTime(iso: string, now: number): string {
@@ -293,15 +281,12 @@ function AgentChatInner({
   const firstName = userCtx?.profile?.first_name ?? null;
 
   const [conversation, setConversation] = useState<Conversation | null>(null);
-  const [allConversations, setAllConversations] = useState<Conversation[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [deleting, setDeleting] = useState(false);
 
   const localIdRef = useRef(0);
   const conversationRef = useRef<Conversation | null>(null);
@@ -317,8 +302,6 @@ function AgentChatInner({
     let cancelled = false;
     (async () => {
       try {
-        const listPromise = authFetch("/api/agent/conversations");
-
         if (initialConversationId) {
           const convRes = await authFetch(
             `/api/agent/conversations/${initialConversationId}`,
@@ -336,13 +319,6 @@ function AgentChatInner({
           setConversation(body.conversation ?? null);
           setMessages(rowsToMessages(body.messages ?? []));
           writeSessionConvId(initialConversationId);
-        }
-
-        const listRes = await listPromise;
-        if (cancelled) return;
-        if (listRes.ok) {
-          const listBody = await listRes.json();
-          if (!cancelled) setAllConversations(listBody.conversations ?? []);
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load");
@@ -506,8 +482,6 @@ function AgentChatInner({
         }
       }
       if (streamErr) throw new Error(streamErr);
-
-      void refreshConversationList();
     } catch (err) {
       const errMessage = err instanceof Error ? err.message : "Failed to send";
       setError(errMessage);
@@ -595,17 +569,6 @@ function AgentChatInner({
     }
   }
 
-  async function refreshConversationList() {
-    try {
-      const res = await authFetch("/api/agent/conversations");
-      if (!res.ok) return;
-      const body = await res.json();
-      setAllConversations(body.conversations ?? []);
-    } catch {
-      // Silent.
-    }
-  }
-
   function switchTo(id: string) {
     if (conversation?.id === id || sending) return;
     setError(null);
@@ -620,27 +583,12 @@ function AgentChatInner({
     onSwitch(null);
   }
 
-  async function confirmDelete() {
-    const id = pendingDeleteId;
-    if (!id || sending) return;
-    setDeleting(true);
-    try {
-      const res = await authFetch(`/api/agent/conversations/${id}`, {
-        method: "DELETE",
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body?.error || `Delete failed (${res.status})`);
-      }
-      setAllConversations((prev) => prev.filter((c) => c.id !== id));
-      setPendingDeleteId(null);
-      if (conversation?.id === id) {
-        onSwitch(null);
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to delete");
-    } finally {
-      setDeleting(false);
+  function handleDeleted(id: string) {
+    // If the user deleted the conversation they're currently viewing,
+    // bounce out to the welcome screen — staying on it would show
+    // stale messages for a row that no longer exists server-side.
+    if (conversation?.id === id) {
+      onSwitch(null);
     }
   }
 
@@ -682,10 +630,7 @@ function AgentChatInner({
           only shows while the overlay is open. */}
       <button
         type="button"
-        onClick={() => {
-          setDrawerOpen(true);
-          void refreshConversationList();
-        }}
+        onClick={() => setDrawerOpen(true)}
         aria-label="Conversation history"
         className="absolute top-4 left-4 z-10 inline-flex items-center justify-center h-9 w-9 rounded-full text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)] transition-colors"
       >
@@ -792,56 +737,13 @@ function AgentChatInner({
         </div>
       )}
 
-      <Drawer
+      <AgentHistoryDrawer
         isOpen={drawerOpen}
         onClose={() => setDrawerOpen(false)}
-        title="Conversations"
-        size="sm"
-      >
-        <div className="space-y-1">
-          {conversation && (
-            <button
-              type="button"
-              onClick={newChat}
-              className="w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)]/60 transition-colors"
-            >
-              <FiPlus className="h-4 w-4 text-[var(--color-muted)]" />
-              New chat
-            </button>
-          )}
-
-          {allConversations.length === 0 ? (
-            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
-              No past conversations.
-            </div>
-          ) : (
-            <div className={conversation ? "pt-2" : ""}>
-              {allConversations.map((c) => (
-                <ConversationRow
-                  key={c.id}
-                  conversation={c}
-                  active={conversation?.id === c.id}
-                  onClick={() => switchTo(c.id)}
-                  onDelete={() => setPendingDeleteId(c.id)}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      </Drawer>
-
-      <ConfirmOverlay
-        isOpen={pendingDeleteId !== null}
-        onCancel={() => {
-          if (!deleting) setPendingDeleteId(null);
-        }}
-        onConfirm={confirmDelete}
-        title="Delete conversation?"
-        description="This permanently removes the conversation and all of its messages."
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
-        variant="danger"
-        busy={deleting}
+        activeConversationId={conversation?.id ?? null}
+        onSelect={switchTo}
+        onNewChat={conversation ? newChat : undefined}
+        onDeleted={handleDeleted}
       />
     </div>
   );
@@ -850,55 +752,6 @@ function AgentChatInner({
 // ──────────────────────────────────────────────────────────────────────────
 // Sub-components
 // ──────────────────────────────────────────────────────────────────────────
-
-function ConversationRow({
-  conversation,
-  active,
-  onClick,
-  onDelete,
-}: {
-  conversation: Conversation;
-  active: boolean;
-  onClick: () => void;
-  onDelete: () => void;
-}) {
-  const [now, setNow] = useState<number | null>(null);
-  useEffect(() => setNow(Date.now()), []);
-
-  const title = conversation.title?.trim() || "Untitled";
-
-  return (
-    <div
-      className={`group relative flex items-center gap-1 rounded-md transition-colors ${
-        active
-          ? "bg-[var(--color-surface-alt)]"
-          : "hover:bg-[var(--color-surface-alt)]/60"
-      }`}
-    >
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex-1 min-w-0 text-left px-2 py-1.5"
-      >
-        <div className="text-sm text-[var(--color-fg)] truncate">{title}</div>
-        <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
-          {now !== null ? formatRelative(conversation.last_message_at, now) : ""}
-        </div>
-      </button>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete();
-        }}
-        aria-label="Delete conversation"
-        className="flex-shrink-0 inline-flex items-center justify-center h-7 w-7 mr-1 rounded-md text-[var(--color-muted)] opacity-0 group-hover:opacity-100 hover:bg-[var(--color-fg)]/[0.08] hover:text-[var(--color-danger)] transition-opacity"
-      >
-        <FiTrash2 className="h-3.5 w-3.5" />
-      </button>
-    </div>
-  );
-}
 
 const INPUT_MAX_HEIGHT_PX = 160;
 

--- a/apps/finance/src/components/agent/AgentHistoryDrawer.tsx
+++ b/apps/finance/src/components/agent/AgentHistoryDrawer.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FiPlus, FiTrash2 } from "react-icons/fi";
+import { ConfirmOverlay, Drawer } from "@zervo/ui";
+import { authFetch } from "../../lib/api/fetch";
+
+type Conversation = {
+  id: string;
+  title: string | null;
+  last_message_at: string;
+};
+
+function formatRelative(iso: string, now: number): string {
+  const ts = new Date(iso).getTime();
+  const diffMin = Math.floor((now - ts) / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+type AgentHistoryDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Highlight the row for the conversation currently being viewed. */
+  activeConversationId?: string | null;
+  /** Called when the user picks a conversation from the list. */
+  onSelect: (id: string) => void;
+  /**
+   * Optional "new chat" affordance shown at the top of the list.
+   * Only meaningful when the caller has an active conversation (e.g.
+   * AgentChat inside the overlay) — bottom-input callers should leave
+   * this off, since they're already at "new chat" by default.
+   */
+  onNewChat?: () => void;
+  /**
+   * Called after a conversation is successfully deleted. AgentChat
+   * uses this to bounce out of the deleted conversation if it was
+   * the one being viewed.
+   */
+  onDeleted?: (id: string) => void;
+};
+
+/**
+ * Shared conversation-history drawer. Used by:
+ *   - AgentChat (inside the overlay) for switching between threads
+ *   - BottomAgentInput (focused-state) for jumping into a thread
+ *
+ * Both open the same drawer from the same edge (left), with the
+ * same row template and delete affordance, so users see the same
+ * UI no matter where they invoke history. The drawer manages its
+ * own list state and refetches on every open so a thread created
+ * elsewhere in the session shows up without a parent prop dance.
+ */
+export default function AgentHistoryDrawer({
+  isOpen,
+  onClose,
+  activeConversationId,
+  onSelect,
+  onNewChat,
+  onDeleted,
+}: AgentHistoryDrawerProps) {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [nowAtMount, setNowAtMount] = useState<number | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => setNowAtMount(Date.now()), []);
+
+  // Refetch on every open so the list reflects whatever's happened
+  // since the user last viewed it (new threads, deletions in another
+  // tab, etc).
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await authFetch("/api/agent/conversations");
+        if (!res.ok || cancelled) return;
+        const body = await res.json();
+        if (!cancelled) setConversations(body.conversations ?? []);
+      } catch {
+        // Silent — drawer still works without the list.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  async function confirmDelete() {
+    const id = pendingDeleteId;
+    if (!id || deleting) return;
+    setDeleting(true);
+    try {
+      const res = await authFetch(`/api/agent/conversations/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) return;
+      setConversations((prev) => prev.filter((c) => c.id !== id));
+      setPendingDeleteId(null);
+      onDeleted?.(id);
+    } catch {
+      // Silent — user can retry.
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <Drawer
+        isOpen={isOpen}
+        onClose={onClose}
+        title="Conversations"
+        size="sm"
+        side="left"
+      >
+        <div className="space-y-1">
+          {onNewChat && (
+            <button
+              type="button"
+              onClick={onNewChat}
+              className="w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)]/60 transition-colors"
+            >
+              <FiPlus className="h-4 w-4 text-[var(--color-muted)]" />
+              New chat
+            </button>
+          )}
+
+          {loading && conversations.length === 0 ? (
+            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
+              Loading…
+            </div>
+          ) : conversations.length === 0 ? (
+            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
+              No past conversations.
+            </div>
+          ) : (
+            <div className={onNewChat ? "pt-2" : ""}>
+              {conversations.map((c) => {
+                const active = activeConversationId === c.id;
+                return (
+                  <div
+                    key={c.id}
+                    className={`group relative flex items-center gap-1 rounded-md transition-colors ${
+                      active
+                        ? "bg-[var(--color-surface-alt)]"
+                        : "hover:bg-[var(--color-surface-alt)]/60"
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => onSelect(c.id)}
+                      className="flex-1 min-w-0 text-left px-2 py-2"
+                    >
+                      <div className="text-sm text-[var(--color-fg)] truncate">
+                        {c.title?.trim() || "Untitled"}
+                      </div>
+                      <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
+                        {nowAtMount !== null
+                          ? formatRelative(c.last_message_at, nowAtMount)
+                          : ""}
+                      </div>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setPendingDeleteId(c.id);
+                      }}
+                      aria-label="Delete conversation"
+                      className="flex-shrink-0 inline-flex items-center justify-center h-7 w-7 mr-1 rounded-md text-[var(--color-muted)] opacity-0 group-hover:opacity-100 hover:bg-[var(--color-fg)]/[0.08] hover:text-[var(--color-danger)] transition-opacity"
+                    >
+                      <FiTrash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </Drawer>
+
+      <ConfirmOverlay
+        isOpen={pendingDeleteId !== null}
+        onCancel={() => {
+          if (!deleting) setPendingDeleteId(null);
+        }}
+        onConfirm={confirmDelete}
+        title="Delete conversation?"
+        description="This permanently removes the conversation and all of its messages."
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        variant="danger"
+        busy={deleting}
+      />
+    </>
+  );
+}

--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -2,40 +2,16 @@
 
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { FiArrowUp, FiClock, FiTrash2 } from "react-icons/fi";
-import { ConfirmOverlay, Drawer } from "@zervo/ui";
-import { authFetch } from "../../lib/api/fetch";
+import { FiArrowUp, FiClock } from "react-icons/fi";
 import { useAgentOverlay } from "./AgentOverlayProvider";
-
-type Conversation = {
-  id: string;
-  title: string | null;
-  last_message_at: string;
-};
-
-function formatRelative(iso: string, now: number): string {
-  const ts = new Date(iso).getTime();
-  const diffMin = Math.floor((now - ts) / 60_000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return new Date(iso).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
-}
+import AgentHistoryDrawer from "./AgentHistoryDrawer";
 
 /**
  * Persistent bottom-of-viewport input for summoning the agent from
  * anywhere in the app. Default state: a flat resting pill at the
- * bottom. Focused state: lifts to the vertical center, reveals a
- * Recent panel above it for one-tap resume of the most recent
- * conversations, and surfaces a top-left history button that opens a
- * drawer with the full conversation list. Submitting opens the
- * overlay with the message pre-fired.
+ * bottom. Focused state: lifts to the vertical center, frosted
+ * backdrop fades in behind, and a top-left clock surfaces a
+ * conversation-history drawer (shared with the in-overlay chat).
  *
  * Hidden while the overlay itself is open — the overlay has its own
  * input and history affordances.
@@ -44,27 +20,15 @@ export default function BottomAgentInput() {
   const { isOpen, open } = useAgentOverlay();
   const [value, setValue] = useState("");
   const [expanded, setExpanded] = useState(false);
-  const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [loadedOnce, setLoadedOnce] = useState(false);
-  const [loadingConversations, setLoadingConversations] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [deleting, setDeleting] = useState(false);
   // Translate-Y in pixels needed to land the input pill at the
   // vertical center of the viewport. Recomputed on resize so it
   // stays accurate across orientation / window changes. SSR-safe:
   // starts at 0 (bottom-anchored), populated on mount.
   const [centerOffsetPx, setCenterOffsetPx] = useState(0);
-  // Single timestamp captured on mount so the drawer rows don't
-  // re-render their relative-time labels every tick. Good enough for
-  // the bottom input; if a user keeps the drawer open for hours the
-  // numbers go stale but reopen refreshes them.
-  const [nowAtMount, setNowAtMount] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => setNowAtMount(Date.now()), []);
 
   useEffect(() => {
     function recompute() {
@@ -81,34 +45,6 @@ export default function BottomAgentInput() {
     window.addEventListener("resize", recompute);
     return () => window.removeEventListener("resize", recompute);
   }, []);
-
-  // Lazy-load the conversation list. We fire on first expand AND on
-  // every drawer open: first expand keeps page-load cost at zero for
-  // users who never touch the agent; the drawer open path is a refresh
-  // so a thread the user just had in the overlay shows up here without
-  // a full page reload, and recovers from a previous failed fetch.
-  useEffect(() => {
-    if (!expanded && !drawerOpen) return;
-    if (loadedOnce && !drawerOpen) return;
-    setLoadedOnce(true);
-    setLoadingConversations(true);
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await authFetch("/api/agent/conversations");
-        if (!res.ok || cancelled) return;
-        const body = await res.json();
-        if (!cancelled) setConversations(body.conversations ?? []);
-      } catch {
-        // Silent — input still works without history visible.
-      } finally {
-        if (!cancelled) setLoadingConversations(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [expanded, drawerOpen, loadedOnce]);
 
   // Click outside collapses. Paused while the drawer is open — the
   // drawer renders via portal at body level, so its clicks count as
@@ -151,8 +87,8 @@ export default function BottomAgentInput() {
     // Force a fresh chat: the bottom input is for "ask Zervo a quick
     // question", which usually has nothing to do with whatever
     // conversation sessionStorage happens to point at. Users who
-    // want to continue an existing thread go through the Recent
-    // panel below or the history drawer at top-left.
+    // want to continue an existing thread go through the history
+    // drawer at top-left.
     open({ initialMessage: trimmed, conversationId: null });
     setValue("");
     setExpanded(false);
@@ -163,24 +99,6 @@ export default function BottomAgentInput() {
     setExpanded(false);
     setDrawerOpen(false);
     setValue("");
-  }
-
-  async function confirmDelete() {
-    const id = pendingDeleteId;
-    if (!id || deleting) return;
-    setDeleting(true);
-    try {
-      const res = await authFetch(`/api/agent/conversations/${id}`, {
-        method: "DELETE",
-      });
-      if (!res.ok) return;
-      setConversations((prev) => prev.filter((c) => c.id !== id));
-      setPendingDeleteId(null);
-    } catch {
-      // Silent — user can retry.
-    } finally {
-      setDeleting(false);
-    }
   }
 
   const hasText = value.trim().length > 0;
@@ -241,71 +159,10 @@ export default function BottomAgentInput() {
           )}
         </AnimatePresence>
 
-        <Drawer
+        <AgentHistoryDrawer
           isOpen={drawerOpen}
           onClose={() => setDrawerOpen(false)}
-          title="Conversations"
-          size="sm"
-          side="left"
-        >
-          {loadingConversations && conversations.length === 0 ? (
-            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
-              Loading…
-            </div>
-          ) : conversations.length === 0 ? (
-            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
-              No past conversations.
-            </div>
-          ) : (
-            <div className="space-y-0.5">
-              {conversations.map((c) => (
-                <div
-                  key={c.id}
-                  className="group relative flex items-center gap-1 rounded-md hover:bg-[var(--color-surface-alt)]/60 transition-colors"
-                >
-                  <button
-                    type="button"
-                    onClick={() => openConversation(c.id)}
-                    className="flex-1 min-w-0 text-left px-2 py-2"
-                  >
-                    <div className="text-sm text-[var(--color-fg)] truncate">
-                      {c.title?.trim() || "Untitled"}
-                    </div>
-                    <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
-                      {nowAtMount !== null
-                        ? formatRelative(c.last_message_at, nowAtMount)
-                        : ""}
-                    </div>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setPendingDeleteId(c.id);
-                    }}
-                    aria-label="Delete conversation"
-                    className="flex-shrink-0 inline-flex items-center justify-center h-7 w-7 mr-1 rounded-md text-[var(--color-muted)] opacity-0 group-hover:opacity-100 hover:bg-[var(--color-fg)]/[0.08] hover:text-[var(--color-danger)] transition-opacity"
-                  >
-                    <FiTrash2 className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </Drawer>
-
-        <ConfirmOverlay
-          isOpen={pendingDeleteId !== null}
-          onCancel={() => {
-            if (!deleting) setPendingDeleteId(null);
-          }}
-          onConfirm={confirmDelete}
-          title="Delete conversation?"
-          description="This permanently removes the conversation and all of its messages."
-          confirmLabel="Delete"
-          cancelLabel="Cancel"
-          variant="danger"
-          busy={deleting}
+          onSelect={openConversation}
         />
       </div>
 
@@ -314,10 +171,6 @@ export default function BottomAgentInput() {
           <motion.div
             key="bottom-agent-input"
             ref={containerRef}
-            // z-[60] keeps the pill above the focused-state backdrop
-            // (z-[55]) and above the sidebar/topbar so the pill — and
-            // its expanded recent-history panel — float cleanly over
-            // the rest of the chrome when active.
             className="fixed inset-x-0 bottom-0 z-[60] pointer-events-none flex justify-center pb-3 md:pb-5 md:pl-20"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: expanded ? centerOffsetPx : 0 }}


### PR DESCRIPTION
## Summary
Two history drawers had drifted into separate implementations — delete worked only in the overlay version, one slid in from the right and the other from the left. Pulled them into a shared `AgentHistoryDrawer`, both `side="left"`.

The shared component owns:
- Conversation list state (refetches on every open)
- Loading + empty + populated rendering
- Delete affordance (hover trash icon + ConfirmOverlay)

Props let callers customize:
- `activeConversationId` — for row highlighting
- `onSelect` — picked-row handler
- `onNewChat` — optional "New chat" row at the top (AgentChat sets this when a conversation is open)
- `onDeleted` — fires after a successful delete (AgentChat uses it to bounce out of the welcome screen if the deleted thread was the one being viewed)

Cleanup in AgentChat: removed `allConversations` state, the secondary list fetch in the load effect, `refreshConversationList`, the post-stream refresh, `pendingDeleteId`/`deleting`, `confirmDelete`, the inline `ConversationRow` component, and the now-unused `formatRelative` helper.

## Test plan
- [ ] Bottom-input history drawer slides in from the **left**
- [ ] In-overlay history drawer (clock at top-left of the chat) also slides in from the **left**
- [ ] Both show the full conversation list, refetched on each open
- [ ] Hover a row in either drawer — trash icon fades in
- [ ] Delete from either drawer — confirms, removes locally, hits DELETE API
- [ ] Inside the overlay: deleting the currently-viewed conversation bounces back to the welcome screen
- [ ] Inside the overlay: with a conversation active, a "New chat" row appears at the top of the drawer
- [ ] Selecting a row in the bottom drawer opens the overlay scoped to that conversation

---
_Generated by [Claude Code](https://claude.ai/code/session_019ihFRL7yq11uESuH4NMusw)_