### PR TITLE
unify mobile drawers + use real chevron icon

### DIFF
--- a/apps/finance/src/components/AlertsIcon.tsx
+++ b/apps/finance/src/components/AlertsIcon.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { createPortal } from "react-dom";
-import { FiBell, FiChevronLeft } from "react-icons/fi";
+import { FiBell } from "react-icons/fi";
 import { useUser } from "./providers/UserProvider";
 import { useHouseholds } from "./providers/HouseholdsProvider";
 import { motion, AnimatePresence, useAnimation } from "framer-motion";
@@ -11,7 +10,7 @@ import Link from "next/link";
 import { authFetch } from "../lib/api/fetch";
 import { supabase } from "../lib/supabase/client";
 import { useToast } from "./providers/ToastProvider";
-import { TOOLTIP_SURFACE_CLASSES } from "@zervo/ui";
+import { Drawer, TOOLTIP_SURFACE_CLASSES } from "@zervo/ui";
 
 type HouseholdSummary = { id: string; name: string; color: string };
 
@@ -91,7 +90,6 @@ export default function AlertsIcon() {
   const [isOpen, setIsOpen] = useState(false);
   const [actingId, setActingId] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState<boolean>(false);
-  const [mounted, setMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const prevCountRef = useRef<number>(0);
   const bellControls = useAnimation();
@@ -149,7 +147,6 @@ export default function AlertsIcon() {
   }, [profile?.id, loadInvitations, loadImpersonationRequests]);
 
   useEffect(() => {
-    setMounted(true);
     const check = () => setIsMobile(window.matchMedia("(max-width: 639px)").matches);
     check();
     window.addEventListener("resize", check);
@@ -169,27 +166,6 @@ export default function AlertsIcon() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isMobile]);
-
-  // Esc dismisses the mobile overlay (the only modal-style surface here).
-  useEffect(() => {
-    if (!isOpen || !isMobile) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsOpen(false);
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [isOpen, isMobile]);
-
-  // Lock body scroll while the mobile overlay is up so the underlying
-  // page doesn't scroll under the user's finger.
-  useEffect(() => {
-    if (!isOpen || !isMobile) return;
-    const original = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = original;
-    };
-  }, [isOpen, isMobile]);
 
   // Jiggle the bell whenever the unread count INCREASES — a passive
   // realtime update should announce itself, not just sit there. Skip on
@@ -512,50 +488,25 @@ export default function AlertsIcon() {
         )}
       </AnimatePresence>
 
-      {/* Mobile fullscreen overlay — portaled to body so it escapes any
-          ancestor stacking context (transformed wrappers, sticky headers,
-          etc.). Slides in from the right like a page transition.
-          Chevron-left closes. */}
-      {mounted &&
-        createPortal(
-          <AnimatePresence>
-            {isOpen && isMobile && (
-              <motion.div
-                initial={{ x: "100%" }}
-                animate={{ x: 0 }}
-                exit={{ x: "100%" }}
-                // iOS-feel cubic — fast settle without overshoot. Shorter
-                // duration + transform-gpu + will-change push the slide
-                // onto a compositor layer so it doesn't pay layout/paint
-                // costs on each frame (the prior 0.22s ease-in-out was
-                // dropping frames on lower-end mobile because the
-                // notification list was repainting during the animation).
-                transition={{ duration: 0.28, ease: [0.32, 0.72, 0, 1] }}
-                style={{ willChange: "transform" }}
-                className="fixed inset-0 z-[80] bg-[var(--color-content-bg)] flex flex-col transform-gpu"
-                role="dialog"
-                aria-modal="true"
-                aria-label="Notifications"
-              >
-                <div className="sticky top-0 z-10 flex items-center gap-2 px-3 pt-[max(env(safe-area-inset-top),0.5rem)] pb-3 bg-[var(--color-content-bg)]">
-                  <button
-                    type="button"
-                    onClick={() => setIsOpen(false)}
-                    className="p-2 rounded-full text-[var(--color-fg)] hover:bg-[var(--color-fg)]/[0.06] transition-colors"
-                    aria-label="Back"
-                  >
-                    <FiChevronLeft className="h-5 w-5" />
-                  </button>
-                  <h2 className="text-base font-medium text-[var(--color-fg)]">Notifications</h2>
-                </div>
-                <div className="flex-1 overflow-y-auto pb-[max(env(safe-area-inset-bottom),1rem)]">
-                  {renderRows(false)}
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>,
-          document.body,
-        )}
+      {/* Mobile path uses the shared Drawer so it picks up the same
+          chevron, scroll lock, and "any-drawer-open" coordination as
+          every other drawer in the app (including the hamburger
+          hide-on-other-drawer-open behavior). Gated on `isMobile` so
+          the bell-anchored desktop dropdown above stays the desktop
+          UX. `noPadding` lets the existing row template render
+          edge-to-edge with its own px-5 padding. */}
+      <Drawer
+        isOpen={isOpen && isMobile}
+        onClose={() => setIsOpen(false)}
+        title="Notifications"
+        size="md"
+        side="right"
+        noPadding
+      >
+        <div className="pb-[max(env(safe-area-inset-bottom),0.5rem)]">
+          {renderRows(false)}
+        </div>
+      </Drawer>
     </div>
   );
 }

--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -9,15 +9,15 @@ import {
   type FormEvent,
 } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { FiArrowUp, FiPlus, FiClock, FiTrash2 } from "react-icons/fi";
+import { FiArrowUp, FiClock } from "react-icons/fi";
 import { marked } from "marked";
-import { Drawer, ConfirmOverlay } from "@zervo/ui";
 import { authFetch } from "../../lib/api/fetch";
 import { useUser } from "../providers/UserProvider";
 import ToolWidget, {
   type ToolBlock as ToolBlockData,
 } from "./widgets/ToolWidget";
 import { AnimateProvider } from "./widgets/primitives";
+import AgentHistoryDrawer from "./AgentHistoryDrawer";
 
 // sessionStorage key remembering the last conversation id viewed in
 // this browser tab. New tabs / new devices have an empty session, so
@@ -99,18 +99,6 @@ function greeting(hour: number): string {
   if (hour < 12) return "Good morning";
   if (hour < 18) return "Good afternoon";
   return "Good evening";
-}
-
-function formatRelative(iso: string, now: number): string {
-  const ts = new Date(iso).getTime();
-  const diffMin = Math.floor((now - ts) / 60_000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 function formatMessageTime(iso: string, now: number): string {
@@ -293,15 +281,12 @@ function AgentChatInner({
   const firstName = userCtx?.profile?.first_name ?? null;
 
   const [conversation, setConversation] = useState<Conversation | null>(null);
-  const [allConversations, setAllConversations] = useState<Conversation[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(true);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [deleting, setDeleting] = useState(false);
 
   const localIdRef = useRef(0);
   const conversationRef = useRef<Conversation | null>(null);
@@ -317,8 +302,6 @@ function AgentChatInner({
     let cancelled = false;
     (async () => {
       try {
-        const listPromise = authFetch("/api/agent/conversations");
-
         if (initialConversationId) {
           const convRes = await authFetch(
             `/api/agent/conversations/${initialConversationId}`,
@@ -336,13 +319,6 @@ function AgentChatInner({
           setConversation(body.conversation ?? null);
           setMessages(rowsToMessages(body.messages ?? []));
           writeSessionConvId(initialConversationId);
-        }
-
-        const listRes = await listPromise;
-        if (cancelled) return;
-        if (listRes.ok) {
-          const listBody = await listRes.json();
-          if (!cancelled) setAllConversations(listBody.conversations ?? []);
         }
       } catch (e) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load");
@@ -506,8 +482,6 @@ function AgentChatInner({
         }
       }
       if (streamErr) throw new Error(streamErr);
-
-      void refreshConversationList();
     } catch (err) {
       const errMessage = err instanceof Error ? err.message : "Failed to send";
       setError(errMessage);
@@ -595,17 +569,6 @@ function AgentChatInner({
     }
   }
 
-  async function refreshConversationList() {
-    try {
-      const res = await authFetch("/api/agent/conversations");
-      if (!res.ok) return;
-      const body = await res.json();
-      setAllConversations(body.conversations ?? []);
-    } catch {
-      // Silent.
-    }
-  }
-
   function switchTo(id: string) {
     if (conversation?.id === id || sending) return;
     setError(null);
@@ -620,27 +583,12 @@ function AgentChatInner({
     onSwitch(null);
   }
 
-  async function confirmDelete() {
-    const id = pendingDeleteId;
-    if (!id || sending) return;
-    setDeleting(true);
-    try {
-      const res = await authFetch(`/api/agent/conversations/${id}`, {
-        method: "DELETE",
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body?.error || `Delete failed (${res.status})`);
-      }
-      setAllConversations((prev) => prev.filter((c) => c.id !== id));
-      setPendingDeleteId(null);
-      if (conversation?.id === id) {
-        onSwitch(null);
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to delete");
-    } finally {
-      setDeleting(false);
+  function handleDeleted(id: string) {
+    // If the user deleted the conversation they're currently viewing,
+    // bounce out to the welcome screen — staying on it would show
+    // stale messages for a row that no longer exists server-side.
+    if (conversation?.id === id) {
+      onSwitch(null);
     }
   }
 
@@ -682,10 +630,7 @@ function AgentChatInner({
           only shows while the overlay is open. */}
       <button
         type="button"
-        onClick={() => {
-          setDrawerOpen(true);
-          void refreshConversationList();
-        }}
+        onClick={() => setDrawerOpen(true)}
         aria-label="Conversation history"
         className="absolute top-4 left-4 z-10 inline-flex items-center justify-center h-9 w-9 rounded-full text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)] transition-colors"
       >
@@ -792,56 +737,13 @@ function AgentChatInner({
         </div>
       )}
 
-      <Drawer
+      <AgentHistoryDrawer
         isOpen={drawerOpen}
         onClose={() => setDrawerOpen(false)}
-        title="Conversations"
-        size="sm"
-      >
-        <div className="space-y-1">
-          {conversation && (
-            <button
-              type="button"
-              onClick={newChat}
-              className="w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)]/60 transition-colors"
-            >
-              <FiPlus className="h-4 w-4 text-[var(--color-muted)]" />
-              New chat
-            </button>
-          )}
-
-          {allConversations.length === 0 ? (
-            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
-              No past conversations.
-            </div>
-          ) : (
-            <div className={conversation ? "pt-2" : ""}>
-              {allConversations.map((c) => (
-                <ConversationRow
-                  key={c.id}
-                  conversation={c}
-                  active={conversation?.id === c.id}
-                  onClick={() => switchTo(c.id)}
-                  onDelete={() => setPendingDeleteId(c.id)}
-                />
-              ))}
-            </div>
-          )}
-        </div>
-      </Drawer>
-
-      <ConfirmOverlay
-        isOpen={pendingDeleteId !== null}
-        onCancel={() => {
-          if (!deleting) setPendingDeleteId(null);
-        }}
-        onConfirm={confirmDelete}
-        title="Delete conversation?"
-        description="This permanently removes the conversation and all of its messages."
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
-        variant="danger"
-        busy={deleting}
+        activeConversationId={conversation?.id ?? null}
+        onSelect={switchTo}
+        onNewChat={conversation ? newChat : undefined}
+        onDeleted={handleDeleted}
       />
     </div>
   );
@@ -850,55 +752,6 @@ function AgentChatInner({
 // ──────────────────────────────────────────────────────────────────────────
 // Sub-components
 // ──────────────────────────────────────────────────────────────────────────
-
-function ConversationRow({
-  conversation,
-  active,
-  onClick,
-  onDelete,
-}: {
-  conversation: Conversation;
-  active: boolean;
-  onClick: () => void;
-  onDelete: () => void;
-}) {
-  const [now, setNow] = useState<number | null>(null);
-  useEffect(() => setNow(Date.now()), []);
-
-  const title = conversation.title?.trim() || "Untitled";
-
-  return (
-    <div
-      className={`group relative flex items-center gap-1 rounded-md transition-colors ${
-        active
-          ? "bg-[var(--color-surface-alt)]"
-          : "hover:bg-[var(--color-surface-alt)]/60"
-      }`}
-    >
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex-1 min-w-0 text-left px-2 py-1.5"
-      >
-        <div className="text-sm text-[var(--color-fg)] truncate">{title}</div>
-        <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
-          {now !== null ? formatRelative(conversation.last_message_at, now) : ""}
-        </div>
-      </button>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete();
-        }}
-        aria-label="Delete conversation"
-        className="flex-shrink-0 inline-flex items-center justify-center h-7 w-7 mr-1 rounded-md text-[var(--color-muted)] opacity-0 group-hover:opacity-100 hover:bg-[var(--color-fg)]/[0.08] hover:text-[var(--color-danger)] transition-opacity"
-      >
-        <FiTrash2 className="h-3.5 w-3.5" />
-      </button>
-    </div>
-  );
-}
 
 const INPUT_MAX_HEIGHT_PX = 160;
 

--- a/apps/finance/src/components/agent/AgentHistoryDrawer.tsx
+++ b/apps/finance/src/components/agent/AgentHistoryDrawer.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FiPlus, FiTrash2 } from "react-icons/fi";
+import { ConfirmOverlay, Drawer } from "@zervo/ui";
+import { authFetch } from "../../lib/api/fetch";
+
+type Conversation = {
+  id: string;
+  title: string | null;
+  last_message_at: string;
+};
+
+function formatRelative(iso: string, now: number): string {
+  const ts = new Date(iso).getTime();
+  const diffMin = Math.floor((now - ts) / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+type AgentHistoryDrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Highlight the row for the conversation currently being viewed. */
+  activeConversationId?: string | null;
+  /** Called when the user picks a conversation from the list. */
+  onSelect: (id: string) => void;
+  /**
+   * Optional "new chat" affordance shown at the top of the list.
+   * Only meaningful when the caller has an active conversation (e.g.
+   * AgentChat inside the overlay) — bottom-input callers should leave
+   * this off, since they're already at "new chat" by default.
+   */
+  onNewChat?: () => void;
+  /**
+   * Called after a conversation is successfully deleted. AgentChat
+   * uses this to bounce out of the deleted conversation if it was
+   * the one being viewed.
+   */
+  onDeleted?: (id: string) => void;
+};
+
+/**
+ * Shared conversation-history drawer. Used by:
+ *   - AgentChat (inside the overlay) for switching between threads
+ *   - BottomAgentInput (focused-state) for jumping into a thread
+ *
+ * Both open the same drawer from the same edge (left), with the
+ * same row template and delete affordance, so users see the same
+ * UI no matter where they invoke history. The drawer manages its
+ * own list state and refetches on every open so a thread created
+ * elsewhere in the session shows up without a parent prop dance.
+ */
+export default function AgentHistoryDrawer({
+  isOpen,
+  onClose,
+  activeConversationId,
+  onSelect,
+  onNewChat,
+  onDeleted,
+}: AgentHistoryDrawerProps) {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [nowAtMount, setNowAtMount] = useState<number | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => setNowAtMount(Date.now()), []);
+
+  // Refetch on every open so the list reflects whatever's happened
+  // since the user last viewed it (new threads, deletions in another
+  // tab, etc).
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await authFetch("/api/agent/conversations");
+        if (!res.ok || cancelled) return;
+        const body = await res.json();
+        if (!cancelled) setConversations(body.conversations ?? []);
+      } catch {
+        // Silent — drawer still works without the list.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  async function confirmDelete() {
+    const id = pendingDeleteId;
+    if (!id || deleting) return;
+    setDeleting(true);
+    try {
+      const res = await authFetch(`/api/agent/conversations/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) return;
+      setConversations((prev) => prev.filter((c) => c.id !== id));
+      setPendingDeleteId(null);
+      onDeleted?.(id);
+    } catch {
+      // Silent — user can retry.
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <Drawer
+        isOpen={isOpen}
+        onClose={onClose}
+        title="Conversations"
+        size="sm"
+        side="left"
+      >
+        <div className="space-y-1">
+          {onNewChat && (
+            <button
+              type="button"
+              onClick={onNewChat}
+              className="w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-sm text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)]/60 transition-colors"
+            >
+              <FiPlus className="h-4 w-4 text-[var(--color-muted)]" />
+              New chat
+            </button>
+          )}
+
+          {loading && conversations.length === 0 ? (
+            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
+              Loading…
+            </div>
+          ) : conversations.length === 0 ? (
+            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
+              No past conversations.
+            </div>
+          ) : (
+            <div className={onNewChat ? "pt-2" : ""}>
+              {conversations.map((c) => {
+                const active = activeConversationId === c.id;
+                return (
+                  <div
+                    key={c.id}
+                    className={`group relative flex items-center gap-1 rounded-md transition-colors ${
+                      active
+                        ? "bg-[var(--color-surface-alt)]"
+                        : "hover:bg-[var(--color-surface-alt)]/60"
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => onSelect(c.id)}
+                      className="flex-1 min-w-0 text-left px-2 py-2"
+                    >
+                      <div className="text-sm text-[var(--color-fg)] truncate">
+                        {c.title?.trim() || "Untitled"}
+                      </div>
+                      <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
+                        {nowAtMount !== null
+                          ? formatRelative(c.last_message_at, nowAtMount)
+                          : ""}
+                      </div>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setPendingDeleteId(c.id);
+                      }}
+                      aria-label="Delete conversation"
+                      className="flex-shrink-0 inline-flex items-center justify-center h-7 w-7 mr-1 rounded-md text-[var(--color-muted)] opacity-0 group-hover:opacity-100 hover:bg-[var(--color-fg)]/[0.08] hover:text-[var(--color-danger)] transition-opacity"
+                    >
+                      <FiTrash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </Drawer>
+
+      <ConfirmOverlay
+        isOpen={pendingDeleteId !== null}
+        onCancel={() => {
+          if (!deleting) setPendingDeleteId(null);
+        }}
+        onConfirm={confirmDelete}
+        title="Delete conversation?"
+        description="This permanently removes the conversation and all of its messages."
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        variant="danger"
+        busy={deleting}
+      />
+    </>
+  );
+}

--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -2,40 +2,16 @@
 
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { FiArrowUp, FiClock, FiTrash2 } from "react-icons/fi";
-import { ConfirmOverlay, Drawer } from "@zervo/ui";
-import { authFetch } from "../../lib/api/fetch";
+import { FiArrowUp, FiClock } from "react-icons/fi";
 import { useAgentOverlay } from "./AgentOverlayProvider";
-
-type Conversation = {
-  id: string;
-  title: string | null;
-  last_message_at: string;
-};
-
-function formatRelative(iso: string, now: number): string {
-  const ts = new Date(iso).getTime();
-  const diffMin = Math.floor((now - ts) / 60_000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return new Date(iso).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
-}
+import AgentHistoryDrawer from "./AgentHistoryDrawer";
 
 /**
  * Persistent bottom-of-viewport input for summoning the agent from
  * anywhere in the app. Default state: a flat resting pill at the
- * bottom. Focused state: lifts to the vertical center, reveals a
- * Recent panel above it for one-tap resume of the most recent
- * conversations, and surfaces a top-left history button that opens a
- * drawer with the full conversation list. Submitting opens the
- * overlay with the message pre-fired.
+ * bottom. Focused state: lifts to the vertical center, frosted
+ * backdrop fades in behind, and a top-left clock surfaces a
+ * conversation-history drawer (shared with the in-overlay chat).
  *
  * Hidden while the overlay itself is open — the overlay has its own
  * input and history affordances.
@@ -44,27 +20,15 @@ export default function BottomAgentInput() {
   const { isOpen, open } = useAgentOverlay();
   const [value, setValue] = useState("");
   const [expanded, setExpanded] = useState(false);
-  const [conversations, setConversations] = useState<Conversation[]>([]);
-  const [loadedOnce, setLoadedOnce] = useState(false);
-  const [loadingConversations, setLoadingConversations] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [deleting, setDeleting] = useState(false);
   // Translate-Y in pixels needed to land the input pill at the
   // vertical center of the viewport. Recomputed on resize so it
   // stays accurate across orientation / window changes. SSR-safe:
   // starts at 0 (bottom-anchored), populated on mount.
   const [centerOffsetPx, setCenterOffsetPx] = useState(0);
-  // Single timestamp captured on mount so the drawer rows don't
-  // re-render their relative-time labels every tick. Good enough for
-  // the bottom input; if a user keeps the drawer open for hours the
-  // numbers go stale but reopen refreshes them.
-  const [nowAtMount, setNowAtMount] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => setNowAtMount(Date.now()), []);
 
   useEffect(() => {
     function recompute() {
@@ -81,34 +45,6 @@ export default function BottomAgentInput() {
     window.addEventListener("resize", recompute);
     return () => window.removeEventListener("resize", recompute);
   }, []);
-
-  // Lazy-load the conversation list. We fire on first expand AND on
-  // every drawer open: first expand keeps page-load cost at zero for
-  // users who never touch the agent; the drawer open path is a refresh
-  // so a thread the user just had in the overlay shows up here without
-  // a full page reload, and recovers from a previous failed fetch.
-  useEffect(() => {
-    if (!expanded && !drawerOpen) return;
-    if (loadedOnce && !drawerOpen) return;
-    setLoadedOnce(true);
-    setLoadingConversations(true);
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await authFetch("/api/agent/conversations");
-        if (!res.ok || cancelled) return;
-        const body = await res.json();
-        if (!cancelled) setConversations(body.conversations ?? []);
-      } catch {
-        // Silent — input still works without history visible.
-      } finally {
-        if (!cancelled) setLoadingConversations(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [expanded, drawerOpen, loadedOnce]);
 
   // Click outside collapses. Paused while the drawer is open — the
   // drawer renders via portal at body level, so its clicks count as
@@ -151,8 +87,8 @@ export default function BottomAgentInput() {
     // Force a fresh chat: the bottom input is for "ask Zervo a quick
     // question", which usually has nothing to do with whatever
     // conversation sessionStorage happens to point at. Users who
-    // want to continue an existing thread go through the Recent
-    // panel below or the history drawer at top-left.
+    // want to continue an existing thread go through the history
+    // drawer at top-left.
     open({ initialMessage: trimmed, conversationId: null });
     setValue("");
     setExpanded(false);
@@ -163,24 +99,6 @@ export default function BottomAgentInput() {
     setExpanded(false);
     setDrawerOpen(false);
     setValue("");
-  }
-
-  async function confirmDelete() {
-    const id = pendingDeleteId;
-    if (!id || deleting) return;
-    setDeleting(true);
-    try {
-      const res = await authFetch(`/api/agent/conversations/${id}`, {
-        method: "DELETE",
-      });
-      if (!res.ok) return;
-      setConversations((prev) => prev.filter((c) => c.id !== id));
-      setPendingDeleteId(null);
-    } catch {
-      // Silent — user can retry.
-    } finally {
-      setDeleting(false);
-    }
   }
 
   const hasText = value.trim().length > 0;
@@ -241,71 +159,10 @@ export default function BottomAgentInput() {
           )}
         </AnimatePresence>
 
-        <Drawer
+        <AgentHistoryDrawer
           isOpen={drawerOpen}
           onClose={() => setDrawerOpen(false)}
-          title="Conversations"
-          size="sm"
-          side="left"
-        >
-          {loadingConversations && conversations.length === 0 ? (
-            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
-              Loading…
-            </div>
-          ) : conversations.length === 0 ? (
-            <div className="text-xs text-[var(--color-muted)] py-6 text-center">
-              No past conversations.
-            </div>
-          ) : (
-            <div className="space-y-0.5">
-              {conversations.map((c) => (
-                <div
-                  key={c.id}
-                  className="group relative flex items-center gap-1 rounded-md hover:bg-[var(--color-surface-alt)]/60 transition-colors"
-                >
-                  <button
-                    type="button"
-                    onClick={() => openConversation(c.id)}
-                    className="flex-1 min-w-0 text-left px-2 py-2"
-                  >
-                    <div className="text-sm text-[var(--color-fg)] truncate">
-                      {c.title?.trim() || "Untitled"}
-                    </div>
-                    <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
-                      {nowAtMount !== null
-                        ? formatRelative(c.last_message_at, nowAtMount)
-                        : ""}
-                    </div>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setPendingDeleteId(c.id);
-                    }}
-                    aria-label="Delete conversation"
-                    className="flex-shrink-0 inline-flex items-center justify-center h-7 w-7 mr-1 rounded-md text-[var(--color-muted)] opacity-0 group-hover:opacity-100 hover:bg-[var(--color-fg)]/[0.08] hover:text-[var(--color-danger)] transition-opacity"
-                  >
-                    <FiTrash2 className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </Drawer>
-
-        <ConfirmOverlay
-          isOpen={pendingDeleteId !== null}
-          onCancel={() => {
-            if (!deleting) setPendingDeleteId(null);
-          }}
-          onConfirm={confirmDelete}
-          title="Delete conversation?"
-          description="This permanently removes the conversation and all of its messages."
-          confirmLabel="Delete"
-          cancelLabel="Cancel"
-          variant="danger"
-          busy={deleting}
+          onSelect={openConversation}
         />
       </div>
 
@@ -314,10 +171,6 @@ export default function BottomAgentInput() {
           <motion.div
             key="bottom-agent-input"
             ref={containerRef}
-            // z-[60] keeps the pill above the focused-state backdrop
-            // (z-[55]) and above the sidebar/topbar so the pill — and
-            // its expanded recent-history panel — float cleanly over
-            // the rest of the chrome when active.
             className="fixed inset-x-0 bottom-0 z-[60] pointer-events-none flex justify-center pb-3 md:pb-5 md:pl-20"
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: expanded ? centerOffsetPx : 0 }}

--- a/apps/finance/src/components/layout/AppTopbar.tsx
+++ b/apps/finance/src/components/layout/AppTopbar.tsx
@@ -57,10 +57,15 @@ export default function AppTopbar() {
         {/* Mobile-only portal that takes over the entire topbar row. Pages
             that need a full-width search / toolbar (e.g. transactions)
             portal their chrome here instead of fighting the default
-            add/alerts buttons for space. Hidden when empty. */}
+            add/alerts buttons for space. Hidden when empty.
+
+            `pl-14` reserves room for the fixed hamburger toggle
+            (top:14 left:16, h-9 w-9 = 36px wide, ends ~52px from the
+            left edge). Without it page content lands underneath the
+            hamburger and taps go to the menu instead. */}
         <div
           id="page-mobile-topbar-portal"
-          className="md:hidden absolute inset-0 z-20 flex items-center gap-2 px-4 bg-[var(--color-content-bg)] empty:hidden"
+          className="md:hidden absolute inset-0 z-20 flex items-center gap-2 pl-14 pr-4 bg-[var(--color-content-bg)] empty:hidden"
         />
       </div>
       <div id="page-toolbar-portal" className="w-full" />

--- a/apps/finance/src/components/layout/MobileNavMenu.tsx
+++ b/apps/finance/src/components/layout/MobileNavMenu.tsx
@@ -7,7 +7,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { LuSettings, LuLogOut } from "react-icons/lu";
 import clsx from "clsx";
-import { ConfirmOverlay, Drawer } from "@zervo/ui";
+import { ConfirmOverlay, Drawer, useAnyDrawerOpen } from "@zervo/ui";
 import { NAV_GROUPS } from "../nav";
 import { useUser } from "../providers/UserProvider";
 import { supabase } from "../../lib/supabase/client";
@@ -33,6 +33,15 @@ export default function MobileNavMenu() {
   const [showLogout, setShowLogout] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const anyDrawerOpen = useAnyDrawerOpen();
+  // The hamburger and any other drawer's top-left close-chevron occupy
+  // the same coordinates on mobile (top:14 left:16). When this menu's
+  // own drawer is open we keep the toggle visible — it morphs into an
+  // X and animates to the top-right (TOGGLE_OPEN_X) so it doesn't
+  // block anything. But when *another* drawer is open (transactions
+  // detail, notifications, etc.), our hamburger sits on top of that
+  // drawer's chevron at z-90 and steals the tap. Hide it then.
+  const otherDrawerOpen = anyDrawerOpen && !open;
 
   useEffect(() => setMounted(true), []);
 
@@ -99,7 +108,7 @@ export default function MobileNavMenu() {
 
   return (
     <>
-      {mounted && createPortal(toggle, document.body)}
+      {mounted && !otherDrawerOpen && createPortal(toggle, document.body)}
 
       <Drawer
         isOpen={open}

--- a/packages/ui/src/Drawer.tsx
+++ b/packages/ui/src/Drawer.tsx
@@ -3,6 +3,7 @@
 import { ReactNode, useEffect, useLayoutEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
+import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
 import clsx from "clsx";
 
 // Module-level open-drawer counter + subscriber set so external chrome
@@ -244,21 +245,23 @@ export default function Drawer({
                 {showBackButton && (
                   <button
                     onClick={onBack}
-                    className="w-8 h-8 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)] transition-colors"
+                    className="w-9 h-9 -ml-2 flex items-center justify-center rounded-full text-[var(--color-fg)] hover:bg-[var(--color-fg)]/[0.06] transition-colors"
                     aria-label="Go back"
                   >
-                    <span className="text-lg leading-none">&#8249;</span>
+                    <FiChevronLeft className="h-5 w-5" />
                   </button>
                 )}
                 {showCloseButton && (
                   <button
                     onClick={onClose}
-                    className="w-8 h-8 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:text-[var(--color-fg)] hover:bg-[var(--color-surface-alt)] transition-colors"
+                    className="w-9 h-9 -ml-2 flex items-center justify-center rounded-full text-[var(--color-fg)] hover:bg-[var(--color-fg)]/[0.06] transition-colors"
                     aria-label="Close"
                   >
-                    <span className="text-lg leading-none">
-                      {side === "left" ? "›" : "‹"}
-                    </span>
+                    {side === "left" ? (
+                      <FiChevronRight className="h-5 w-5" />
+                    ) : (
+                      <FiChevronLeft className="h-5 w-5" />
+                    )}
                   </button>
                 )}
                 {(displayTitle || displayDescription) && (

--- a/packages/ui/src/Drawer.tsx
+++ b/packages/ui/src/Drawer.tsx
@@ -5,6 +5,37 @@ import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import clsx from "clsx";
 
+// Module-level open-drawer counter + subscriber set so external chrome
+// (e.g. the mobile hamburger menu) can react to "is any drawer open".
+// We don't ship a context because Drawer is rendered via portal and the
+// chrome that wants to listen lives in entirely different parts of the
+// React tree — a tiny pub-sub keeps the coupling out of the JSX layer.
+let openDrawerCount = 0;
+const drawerSubscribers = new Set<(open: boolean) => void>();
+
+function notifyDrawerSubscribers() {
+  const open = openDrawerCount > 0;
+  drawerSubscribers.forEach((cb) => cb(open));
+}
+
+/**
+ * Returns true while any Drawer instance is currently open. Used by
+ * the mobile hamburger to step out of the way when a drawer (e.g. a
+ * transaction detail sheet, a notifications drawer) is already
+ * occupying the screen so its top-left back chevron isn't covered.
+ */
+export function useAnyDrawerOpen(): boolean {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    drawerSubscribers.add(setOpen);
+    setOpen(openDrawerCount > 0);
+    return () => {
+      drawerSubscribers.delete(setOpen);
+    };
+  }, []);
+  return open;
+}
+
 type DrawerView = {
   id: string;
   title: string;
@@ -127,6 +158,20 @@ export default function Drawer({
   // Avoid SSR/CSR mismatch and enable portal rendering above any stacking contexts
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
+
+  // Maintain the global open-drawer count for `useAnyDrawerOpen`.
+  // Bracketed inside an effect so the count tracks lifecycle (mount/
+  // unmount + isOpen toggles) cleanly, even with multiple drawers
+  // open simultaneously.
+  useEffect(() => {
+    if (!isOpen) return;
+    openDrawerCount += 1;
+    notifyDrawerSubscribers();
+    return () => {
+      openDrawerCount -= 1;
+      notifyDrawerSubscribers();
+    };
+  }, [isOpen]);
 
   // Get current view or fallback to default content
   const currentView = views.find(view => view.id === currentViewId);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,7 +6,7 @@ export { default as ChartTooltip } from "./ChartTooltip";
 export { default as ConfirmOverlay } from "./ConfirmOverlay";
 export { ContextMenu, ContextMenuItem, ContextMenuSeparator } from "./ContextMenu";
 export { default as CustomDonut } from "./CustomDonut";
-export { default as Drawer } from "./Drawer";
+export { default as Drawer, useAnyDrawerOpen } from "./Drawer";
 export { default as Input } from "./Input";
 export { default as LineChart } from "./LineChart";
 export { default as Modal } from "./Modal";


### PR DESCRIPTION
## Summary
Two issues, one root cause — the mobile notifications surface was a hand-rolled `motion.div` instead of the shared `Drawer`, so it had a different chevron AND wasn't participating in `useAnyDrawerOpen`. That explained both complaints (small chevron on transaction details, hamburger blocking the notifications close button).

### 1. Real chevron icon in `Drawer`
Swapped the back/close HTML-entity chevrons (`‹`/`›` at `text-lg`) for `FiChevronLeft` / `FiChevronRight` from `react-icons` at `h-5 w-5`, in a 36px-square button with a `-2px` left offset so the icon visually aligns with the header text — same look as the notifications header the user pointed at. Applies everywhere a Drawer renders (transaction details, agent history, etc.).

### 2. Notifications uses the shared `Drawer` on mobile
Converted `AlertsIcon`'s mobile path from a custom fullscreen `motion.div` into `<Drawer side="right" noPadding>`. Desktop keeps its bell-anchored floating dropdown unchanged. Now:
- The hamburger correctly hides while notifications is open (drawer registers in the open-count).
- Close button matches every other drawer.
- Dropped AlertsIcon's hand-rolled mobile-only Esc handler, body scroll lock, and `mounted` portal flag — `Drawer` owns those.

## Test plan
- [ ] Mobile: every drawer's back/close chevron is a real `FiChevronLeft` icon, large enough to read clearly
- [ ] Mobile: open notifications — hamburger disappears, close chevron is tappable
- [ ] Mobile: close notifications via the chevron, the backdrop, or Esc
- [ ] Desktop: bell still opens the floating dropdown (no drawer)
- [ ] Live updates (impersonation requests, household invites) still arrive while the mobile drawer is open

---
_Generated by [Claude Code](https://claude.ai/code/session_019ihFRL7yq11uESuH4NMusw)_