### PR TITLE
hide hamburger when bottom agent input is focused

### DIFF
--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -150,14 +150,14 @@ export default function BottomAgentInput() {
 
   return (
     <>
-      {/* Soft frosted backdrop while the input is focused. Lives in
-          its own AnimatePresence so it can fade independently from
-          the input itself, and sits at z-[55] so the input's z-[60]
-          layer stays above it. The blur uses the same pattern as the
-          full overlay (content-bg tinted, backdrop blur) but lighter
-          — a "preview" of the chat state, not a takeover. */}
+      {/* Soft frosted backdrop while the input is focused. Desktop
+          only — on mobile the keyboard already telegraphs "input
+          mode" and the page underneath is naturally hidden, so the
+          extra blur layer is just visual noise (and potentially a
+          performance hit on mid-range phones). Mobile keeps the pill
+          + history clock on top of the unblurred page. */}
       <AnimatePresence>
-        {!isOpen && expanded && (
+        {!isOpen && expanded && !isMobile && (
           <motion.div
             key="bottom-agent-backdrop"
             className="fixed inset-0 z-[55]"

--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { FiArrowUp, FiClock } from "react-icons/fi";
+import { useRegisterDrawerOpen } from "@zervo/ui";
 import { useAgentOverlay } from "./AgentOverlayProvider";
 import AgentHistoryDrawer from "./AgentHistoryDrawer";
 
@@ -43,6 +44,12 @@ export default function BottomAgentInput() {
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Register the focused state into the drawer-open count so the
+  // mobile hamburger steps out of the way (same path AgentHistoryDrawer
+  // uses). Without this the hamburger keeps sitting on top of the
+  // top-left history clock at z-90 and steals taps.
+  useRegisterDrawerOpen(expanded && !isOpen);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 639px)");

--- a/apps/finance/src/components/agent/BottomAgentInput.tsx
+++ b/apps/finance/src/components/agent/BottomAgentInput.tsx
@@ -8,10 +8,16 @@ import AgentHistoryDrawer from "./AgentHistoryDrawer";
 
 /**
  * Persistent bottom-of-viewport input for summoning the agent from
- * anywhere in the app. Default state: a flat resting pill at the
- * bottom. Focused state: lifts to the vertical center, frosted
- * backdrop fades in behind, and a top-left clock surfaces a
- * conversation-history drawer (shared with the in-overlay chat).
+ * anywhere in the app.
+ *
+ * Desktop: focus lifts the pill to the vertical center, fades in a
+ * frosted backdrop, and surfaces a top-left history clock.
+ *
+ * Mobile: focus does NOT lift. The pill stays anchored to the bottom
+ * and rides above the keyboard via the Visual Viewport API — same
+ * pattern as a chat app input. The lift animation fights with the
+ * keyboard otherwise (the pill hides behind it on iOS), and at the
+ * sizes a phone provides, "lift to center" doesn't add anything.
  *
  * Hidden while the overlay itself is open — the overlay has its own
  * input and history affordances.
@@ -22,13 +28,29 @@ export default function BottomAgentInput() {
   const [expanded, setExpanded] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   // Translate-Y in pixels needed to land the input pill at the
-  // vertical center of the viewport. Recomputed on resize so it
-  // stays accurate across orientation / window changes. SSR-safe:
-  // starts at 0 (bottom-anchored), populated on mount.
+  // vertical center of the viewport. Desktop only — mobile keeps the
+  // pill bottom-anchored and rides the keyboard instead.
   const [centerOffsetPx, setCenterOffsetPx] = useState(0);
+  // True under the sm breakpoint. SSR-safe (starts false, hydrated on
+  // mount) so we don't render a "lifted" state for a frame.
+  const [isMobile, setIsMobile] = useState(false);
+  // How many px the on-screen keyboard is occupying at the bottom of
+  // the viewport (mobile only). Driven by the Visual Viewport API so
+  // we can keep the pill above the keyboard on iOS — `position: fixed;
+  // bottom: 0` sits behind the keyboard there because fixed is
+  // relative to the layout viewport, not the visual one.
+  const [keyboardOffsetPx, setKeyboardOffsetPx] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(max-width: 639px)");
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
 
   useEffect(() => {
     function recompute() {
@@ -44,6 +66,29 @@ export default function BottomAgentInput() {
     recompute();
     window.addEventListener("resize", recompute);
     return () => window.removeEventListener("resize", recompute);
+  }, []);
+
+  // Visual Viewport keyboard tracking. The difference between the
+  // layout viewport (`window.innerHeight`) and the visual viewport
+  // (`vv.height + vv.offsetTop`) is how much the keyboard is
+  // occupying. We only use this on mobile — on desktop there's no
+  // virtual keyboard, so the offset is always 0.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+    function update() {
+      if (!vv) return;
+      const overlap = window.innerHeight - vv.height - vv.offsetTop;
+      setKeyboardOffsetPx(Math.max(0, overlap));
+    }
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
   }, []);
 
   // Click outside collapses. Paused while the drawer is open — the
@@ -173,7 +218,16 @@ export default function BottomAgentInput() {
             ref={containerRef}
             className="fixed inset-x-0 bottom-0 z-[60] pointer-events-none flex justify-center pb-3 md:pb-5 md:pl-20"
             initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: expanded ? centerOffsetPx : 0 }}
+            animate={{
+              opacity: 1,
+              // Mobile: ride the keyboard. Desktop: lift to center on
+              // focus, sit at rest otherwise.
+              y: isMobile
+                ? -keyboardOffsetPx
+                : expanded
+                ? centerOffsetPx
+                : 0,
+            }}
             exit={{ opacity: 0, y: 12 }}
             transition={{ type: "spring", stiffness: 220, damping: 26, mass: 0.8 }}
           >
@@ -211,7 +265,12 @@ export default function BottomAgentInput() {
                     onFocus={() => setExpanded(true)}
                     placeholder="Ask Zervo anything…"
                     aria-label="Ask the agent"
-                    className="flex-1 bg-transparent py-3.5 pl-2.5 pr-12 text-sm text-[var(--color-fg)] placeholder:text-[var(--color-muted)] focus:outline-none"
+                    // text-base on mobile keeps the actual font-size
+                    // at 16px, which is what iOS Safari needs to skip
+                    // the "zoom on focus" gesture; sm:text-sm pulls
+                    // it back to 14px on desktop where the visual
+                    // density of the surrounding chrome lives.
+                    className="flex-1 bg-transparent py-3.5 pl-2.5 pr-12 text-base sm:text-sm text-[var(--color-fg)] placeholder:text-[var(--color-muted)] focus:outline-none"
                   />
                   <AnimatePresence>
                     {hasText && (

--- a/packages/ui/src/Drawer.tsx
+++ b/packages/ui/src/Drawer.tsx
@@ -37,6 +37,29 @@ export function useAnyDrawerOpen(): boolean {
   return open;
 }
 
+/**
+ * Hook for non-Drawer surfaces that occupy the screen the same way a
+ * drawer does — e.g. the bottom agent input's focused state, where
+ * the top-left history clock would otherwise be covered by the
+ * mobile hamburger. Pass `true` while your surface is "open" and the
+ * mobile chrome (hamburger today, anything else later) will react
+ * via `useAnyDrawerOpen` exactly as it does for a real Drawer.
+ *
+ * The Drawer component itself uses this internally — same lifecycle
+ * pattern, no separate channel.
+ */
+export function useRegisterDrawerOpen(isOpen: boolean): void {
+  useEffect(() => {
+    if (!isOpen) return;
+    openDrawerCount += 1;
+    notifyDrawerSubscribers();
+    return () => {
+      openDrawerCount -= 1;
+      notifyDrawerSubscribers();
+    };
+  }, [isOpen]);
+}
+
 type DrawerView = {
   id: string;
   title: string;
@@ -161,18 +184,9 @@ export default function Drawer({
   useEffect(() => setMounted(true), []);
 
   // Maintain the global open-drawer count for `useAnyDrawerOpen`.
-  // Bracketed inside an effect so the count tracks lifecycle (mount/
-  // unmount + isOpen toggles) cleanly, even with multiple drawers
-  // open simultaneously.
-  useEffect(() => {
-    if (!isOpen) return;
-    openDrawerCount += 1;
-    notifyDrawerSubscribers();
-    return () => {
-      openDrawerCount -= 1;
-      notifyDrawerSubscribers();
-    };
-  }, [isOpen]);
+  // Same hook external surfaces (e.g. the agent's focused bottom
+  // input) opt into to suppress the mobile hamburger.
+  useRegisterDrawerOpen(isOpen);
 
   // Get current view or fallback to default content
   const currentView = views.find(view => view.id === currentViewId);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,7 +6,7 @@ export { default as ChartTooltip } from "./ChartTooltip";
 export { default as ConfirmOverlay } from "./ConfirmOverlay";
 export { ContextMenu, ContextMenuItem, ContextMenuSeparator } from "./ContextMenu";
 export { default as CustomDonut } from "./CustomDonut";
-export { default as Drawer, useAnyDrawerOpen } from "./Drawer";
+export { default as Drawer, useAnyDrawerOpen, useRegisterDrawerOpen } from "./Drawer";
 export { default as Input } from "./Input";
 export { default as LineChart } from "./LineChart";
 export { default as Modal } from "./Modal";


### PR DESCRIPTION
## Summary
The mobile hamburger only hides when a real `Drawer` is open (via `useAnyDrawerOpen`). The bottom input's focused state isn't a Drawer, so the hamburger kept sitting at `z-90` on top of the focused-state top-left history clock and stole taps.

Extract the open-counter registration from Drawer's local effect into a public `useRegisterDrawerOpen` hook so non-Drawer surfaces can opt into the same coordination. Drawer continues to use it internally; `BottomAgentInput` now calls it with `expanded && !isOpen` so the hamburger steps out of the way whenever the pill is in its focused state.

## Test plan
- [ ] Mobile: focus the bottom input — hamburger disappears
- [ ] Mobile: top-left history clock is now tappable (was blocked before)
- [ ] Mobile: collapse the focused state — hamburger reappears
- [ ] Mobile: open a real Drawer (e.g. notifications) — still hides hamburger
- [ ] Desktop: nothing visibly changes (hamburger is `md:hidden` regardless)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ihFRL7yq11uESuH4NMusw)_