### PR TITLE
feat(insights): AI-curated dashboard insights via Haiku filter

### DIFF
--- a/apps/finance/src/app/api/dashboard/insights/route.ts
+++ b/apps/finance/src/app/api/dashboard/insights/route.ts
@@ -3,17 +3,28 @@ import { supabaseAdmin } from '../../../../lib/supabase/admin';
 import { canAccess } from '../../../../lib/tierConfig';
 import { identifyTransfers, isTransfer } from '../../../../lib/transfer-matching';
 import { getBudgetProgress } from '../../../../lib/spending';
-import { spendingPace } from '../../../../lib/insights/generators/spendingPace';
-import { budgetAlert } from '../../../../lib/insights/generators/budgetAlert';
-import { upcomingBills } from '../../../../lib/insights/generators/upcomingBills';
-import { topCategoryShift } from '../../../../lib/insights/generators/topCategoryShift';
-import type { Insight } from '../../../../lib/insights/types';
+import { spendingPaceCandidates } from '../../../../lib/insights/generators/spendingPace';
+import { budgetAlertCandidates } from '../../../../lib/insights/generators/budgetAlert';
+import { upcomingBillsCandidates } from '../../../../lib/insights/generators/upcomingBills';
+import { topCategoryShiftCandidates } from '../../../../lib/insights/generators/topCategoryShift';
+import { resolveAgentConfig } from '../../../../lib/agent/platformConfig';
+import {
+  CURATOR_MODEL,
+  curateInsights,
+  fallbackInsights,
+} from '../../../../lib/insights/curator';
+import {
+  fingerprintCandidates,
+  getCachedInsights,
+  writeCachedInsights,
+} from '../../../../lib/insights/cache';
+import type { Insight, InsightCandidate } from '../../../../lib/insights/types';
 
 export const GET = withAuth('dashboard:insights', async (_request, userId) => {
     // Fetch user tier
     const { data: userProfile } = await supabaseAdmin
       .from('user_profiles')
-      .select('subscription_tier')
+      .select('subscription_tier, first_name, monthly_income')
       .eq('id', userId)
       .maybeSingle();
     const tier = userProfile?.subscription_tier || 'free';
@@ -135,23 +146,22 @@ export const GET = withAuth('dashboard:insights', async (_request, userId) => {
       .map((c) => ({ label: c.label, total_spent: c.total }))
       .sort((a, b) => b.total_spent - a.total_spent);
 
-    // ── Run generators ──
-    const insights: Insight[] = [];
+    // ── Run generators (collect all candidates) ──
+    const candidates: InsightCandidate[] = [];
 
     // Spending pace (free)
-    const pace = spendingPace({ currentMonthSpending, lastMonthSpending });
-    if (pace) insights.push(pace);
+    candidates.push(
+      ...spendingPaceCandidates({ currentMonthSpending, lastMonthSpending }),
+    );
 
     // Top category shift (free)
-    const catShift = topCategoryShift({ categories, months });
-    if (catShift) insights.push(catShift);
+    candidates.push(...topCategoryShiftCandidates({ categories, months }));
 
     // Budget alert (pro)
     if (canAccess(tier, 'budgets')) {
       try {
         const budgets = await getBudgetProgress(supabaseAdmin, userId);
-        const alert = budgetAlert(budgets);
-        if (alert) insights.push(alert);
+        candidates.push(...budgetAlertCandidates(budgets));
       } catch (e) {
         console.warn('[insights] budget fetch failed:', e);
       }
@@ -165,16 +175,73 @@ export const GET = withAuth('dashboard:insights', async (_request, userId) => {
           .select('stream_type, predicted_next_date, average_amount, merchant_name')
           .eq('user_id', userId)
           .eq('is_active', true);
-        const bills = upcomingBills(streams || []);
-        if (bills) insights.push(bills);
+        candidates.push(...upcomingBillsCandidates(streams || []));
       } catch (e) {
         console.warn('[insights] recurring fetch failed:', e);
       }
     }
 
-    // Sort: priority ascending, then negative tone first
-    const toneOrder = { negative: 0, neutral: 1, positive: 2 };
-    insights.sort((a, b) => a.priority - b.priority || toneOrder[a.tone] - toneOrder[b.tone]);
+    if (candidates.length === 0) {
+      return Response.json({ insights: [] satisfies Insight[] });
+    }
 
-    return Response.json({ insights });
+    // ── Curator: filter + rephrase via LLM, with cache + fallback ──
+
+    const fingerprint = fingerprintCandidates(candidates);
+
+    const cached = await getCachedInsights(userId, fingerprint);
+    if (cached) {
+      return Response.json({ insights: cached });
+    }
+
+    // Resolve API key (DB-managed via admin app, env-var fallback). If
+    // there's no key configured at all, skip the curator entirely and
+    // serve the deterministic fallback. The dashboard still works; it
+    // just looks like the old behavior until a key is set.
+    let apiKey: string | null = null;
+    try {
+      apiKey = (await resolveAgentConfig()).apiKey;
+    } catch {
+      apiKey = null;
+    }
+
+    if (!apiKey) {
+      const insights = fallbackInsights(candidates);
+      return Response.json({ insights });
+    }
+
+    // Load active memories so the curator has context the data alone
+    // can't show ("user has 2 kids", "mortgage paid from unconnected
+    // account"). Same source the chat agent reads.
+    const { data: memoryRows } = await supabaseAdmin
+      .from('user_agent_memories')
+      .select('content')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: true });
+    const memories = (memoryRows ?? []).map((m) => m.content);
+
+    const curated = await curateInsights({
+      apiKey,
+      candidates,
+      memories,
+      monthlyIncome: userProfile?.monthly_income ?? null,
+      firstName: userProfile?.first_name ?? null,
+    });
+
+    // Curator returned null = API/parse failure. Fall back to the
+    // deterministic top-N so the dashboard never goes empty due to LLM
+    // outages. Don't cache the fallback — we want to retry the curator
+    // on the next request.
+    if (curated === null) {
+      const insights = fallbackInsights(candidates);
+      return Response.json({ insights });
+    }
+
+    // Curator returned [] = nothing was worth surfacing. That's a valid
+    // outcome (better an empty carousel than a noisy one) and we DO
+    // cache it so we don't burn another curator call on the next load.
+    await writeCachedInsights(userId, curated, fingerprint, CURATOR_MODEL);
+
+    return Response.json({ insights: curated });
 });

--- a/apps/finance/src/lib/insights/cache.ts
+++ b/apps/finance/src/lib/insights/cache.ts
@@ -1,0 +1,85 @@
+/**
+ * Cache helpers for AI-curated dashboard insights.
+ *
+ * Two invalidation triggers (whichever fires first):
+ *   - TTL: regenerate if `now > expires_at` (~6h default).
+ *   - Fingerprint: regenerate if the candidate set changed even within
+ *     the TTL window. Catches "user accepted a budget proposal", "new
+ *     transactions synced", etc.
+ *
+ * The fingerprint is computed from each candidate's id + a stable
+ * stringification of its context. Sort first so order doesn't affect
+ * the hash.
+ */
+import { createHash } from 'node:crypto';
+import { supabaseAdmin } from '../supabase/admin';
+import type { Insight, InsightCandidate } from './types';
+
+// 6 hours. Long enough that a normal day of dashboard loads only
+// triggers one curator call; short enough that "I accepted that budget
+// proposal yesterday, why is my dashboard still showing it?" doesn't
+// linger past a sleep cycle.
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Stable fingerprint of the candidate set. Two candidate sets that
+ * would produce the same curation output should hash to the same value
+ * — id + structured context covers it.
+ */
+export function fingerprintCandidates(candidates: InsightCandidate[]): string {
+  const normalized = candidates
+    .map((c) => ({ id: c.id, kind: c.kind, context: c.context }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  return createHash('sha256').update(JSON.stringify(normalized)).digest('hex');
+}
+
+interface CachedRow {
+  insights: Insight[];
+  candidate_fingerprint: string;
+  expires_at: string;
+}
+
+/**
+ * Returns the cached insights if (a) a row exists, (b) it hasn't
+ * expired, and (c) the candidate fingerprint still matches. Otherwise
+ * returns null and the caller re-curates.
+ */
+export async function getCachedInsights(
+  userId: string,
+  fingerprint: string,
+): Promise<Insight[] | null> {
+  const { data } = await supabaseAdmin
+    .from('user_agent_insight_cache')
+    .select('insights, candidate_fingerprint, expires_at')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (!data) return null;
+  const row = data as unknown as CachedRow;
+  if (row.candidate_fingerprint !== fingerprint) return null;
+  if (new Date(row.expires_at).getTime() <= Date.now()) return null;
+  if (!Array.isArray(row.insights)) return null;
+
+  return row.insights;
+}
+
+export async function writeCachedInsights(
+  userId: string,
+  insights: Insight[],
+  fingerprint: string,
+  model: string,
+): Promise<void> {
+  const expiresAt = new Date(Date.now() + CACHE_TTL_MS).toISOString();
+  await supabaseAdmin
+    .from('user_agent_insight_cache')
+    .upsert(
+      {
+        user_id: userId,
+        insights: insights as unknown as never,
+        candidate_fingerprint: fingerprint,
+        expires_at: expiresAt,
+        model,
+      },
+      { onConflict: 'user_id' },
+    );
+}

--- a/apps/finance/src/lib/insights/curator.ts
+++ b/apps/finance/src/lib/insights/curator.ts
@@ -1,0 +1,301 @@
+/**
+ * AI curator for dashboard insights.
+ *
+ * Generators produce candidates from the user's data — every signal
+ * they can find, not just the "interesting" ones. This module is the
+ * filter: a single Haiku call looks at all candidates plus the user's
+ * memory + profile and picks the 2-3 worth surfacing, rewriting them
+ * in plain language.
+ *
+ * Why split it this way:
+ *   - Generators are deterministic and cheap. They emit facts.
+ *   - The curator brings judgment. It knows that a mortgage budget at
+ *     100% on day 5 is expected (fixed recurring), but a dining
+ *     budget at 100% on day 12 is not.
+ *   - Numbers in the curated output come from the candidate context,
+ *     so the model can't hallucinate dollar amounts. It can pick,
+ *     drop, reorder, and rephrase, but it can't invent.
+ *
+ * Failure mode: if the API call fails or returns garbage, the route
+ * falls back to deterministic top-N candidates rendered with their
+ * default messages. The dashboard never goes empty because of an LLM
+ * outage.
+ */
+import Anthropic from '@anthropic-ai/sdk';
+import { createLogger } from '../logger';
+import type { Insight, InsightCandidate } from './types';
+
+// Haiku 4.5 — fast, cheap (~$1/$5 per million tokens in/out), and smart
+// enough to filter + rewrite a few short signals. The chat agent uses
+// Sonnet 4.6; we don't need that level of reasoning for a curate pass.
+export const CURATOR_MODEL = 'claude-haiku-4-5-20251001';
+
+// Cap on how many curated insights we surface. The carousel auto-rotates
+// every 8s; more than 3 is too many to actually read.
+const MAX_SURFACED = 3;
+
+// Cap on candidate input. The curator scales linearly with candidate
+// count, but in practice generators emit well under this. Hard cap is
+// just a safety net.
+const MAX_CANDIDATES = 20;
+
+interface CurateArgs {
+  apiKey: string;
+  candidates: InsightCandidate[];
+  /** Active facts from user_agent_memories — gives the curator context
+   *  the data alone can't show ("user has 2 kids", "mortgage paid from
+   *  unconnected account"). */
+  memories: string[];
+  /** Monthly take-home, if known. Lets the curator gauge whether a
+   *  $400 swing is meaningful. */
+  monthlyIncome: number | null;
+  /** First name if known, for slightly warmer phrasing. Optional. */
+  firstName: string | null;
+}
+
+const CURATOR_SYSTEM = `You are the curator for a dashboard insights carousel in a personal finance app. The user sees this strip the moment they open the dashboard. Your job is to look at deterministically-generated candidate signals about their finances and return the 1-3 that are genuinely worth a human's attention, rewriting them in plain language.
+
+# What to surface vs skip
+
+SKIP these (the most common failure mode is surfacing obvious things):
+- Fixed recurring bills (mortgage, rent, insurance, real utilities, loan payments) hitting 100% of their budget early in the month. These are paid in full once a month — that's the calendar working as intended, not a warning. The candidate's context.category_type tells you when a budget falls into this bucket.
+- Spending pace differences under ~10% on a partial month. Statistical noise on a small sample.
+- Top category being "high" when the absolute dollar amount is small relative to the user's monthly_income.
+- Generic upcoming-bills counts when the bills are normal recurring expenses the user already knows about. Only surface upcoming bills if the total is unusually large or they cluster in a way the user might miss.
+
+SURFACE these:
+- Variable budgets (dining, shopping, entertainment, travel, personal) tracking ahead of pace — pacing > expected by a meaningful margin with days left.
+- Spending pace shifts of 15%+ on a partial month, or 10%+ once you're past the 15th.
+- A category spending at 1.5x+ its typical monthly average, especially if it's a discretionary category.
+- An upcoming-bills cluster that's notably larger than the user's typical week or includes a bill the user might not be expecting.
+- Honest positive observations when warranted ("you're pacing 20% under last month") — but don't manufacture spin.
+
+If nothing is genuinely interesting, return zero insights. An empty carousel beats a noisy one.
+
+# How to write the message
+
+- Conversational, one short sentence. No headings, no bullets.
+- Lead with the substance, not the framing ("Dining is pacing 40% over last month with 18 days left", not "Here's an insight: ...").
+- Numbers must come from the candidate context. Do not invent figures or percentages.
+- Skip pleasantries ("just a heads up", "FYI"). The carousel position already signals this is for them.
+- Use the user's first name only if it adds warmth (rare).
+- NEVER use em dashes ("—") or spaced hyphens used as dash substitutes ("X - Y"). Use periods, commas, parentheses, or colons. Unspaced hyphens in compounds ("self-driving") and ranges ("$130-180") are fine.
+- Keep titles short (2-4 words). The carousel renders title above message.
+
+# Tone
+
+- 'positive' for genuinely good observations (spending less, under budget pace).
+- 'negative' for things the user should look at (pace ahead, category spike, large upcoming bills).
+- 'neutral' for informational without judgment.
+
+# Output
+
+You will call the \`select_insights\` tool exactly once. The tool takes an array of selected insights, each referencing a candidate.id and providing rewritten title/message/tone. Order the array in priority order — the first element is what the user sees first.`;
+
+const SELECT_INSIGHTS_TOOL: Anthropic.Messages.Tool = {
+  name: 'select_insights',
+  description:
+    'Submit the curated set of insights to surface to the user. ' +
+    'Each entry references a candidate by id and provides rewritten ' +
+    'title/message/tone. Return zero entries if nothing is worth surfacing.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      selected: {
+        type: 'array',
+        maxItems: MAX_SURFACED,
+        description:
+          'Curated insights in priority order. First element is shown ' +
+          'first in the carousel.',
+        items: {
+          type: 'object',
+          required: ['candidate_id', 'title', 'message', 'tone'],
+          properties: {
+            candidate_id: {
+              type: 'string',
+              description:
+                'The id of one of the candidates provided in the user message. ' +
+                'Must match exactly. Do not invent ids.',
+            },
+            title: {
+              type: 'string',
+              description: 'Short title (2-4 words) shown above the message.',
+            },
+            message: {
+              type: 'string',
+              description:
+                'One short conversational sentence. Numbers must come from ' +
+                'the candidate context, not invented.',
+            },
+            tone: {
+              type: 'string',
+              enum: ['positive', 'negative', 'neutral'],
+            },
+          },
+        },
+      },
+    },
+    required: ['selected'],
+  },
+};
+
+interface SelectedItem {
+  candidate_id: string;
+  title: string;
+  message: string;
+  tone: 'positive' | 'negative' | 'neutral';
+}
+
+function buildUserMessage(args: CurateArgs): string {
+  const profileLines: string[] = [];
+  if (args.firstName) profileLines.push(`First name: ${args.firstName}`);
+  if (args.monthlyIncome && args.monthlyIncome > 0) {
+    profileLines.push(
+      `Monthly take-home income: $${args.monthlyIncome.toLocaleString('en-US')}`,
+    );
+  } else {
+    profileLines.push('Monthly income: not set');
+  }
+
+  const memoriesBlock =
+    args.memories.length > 0
+      ? `\n\n# What you know about the user\n${args.memories.map((m) => `- ${m}`).join('\n')}`
+      : '';
+
+  // Compact JSON of candidates — keeps the prompt small while preserving
+  // the structured context fields the model needs to judge relevance.
+  const compactCandidates = args.candidates.slice(0, MAX_CANDIDATES).map((c) => ({
+    id: c.id,
+    kind: c.kind,
+    default_title: c.defaultTitle,
+    default_message: c.defaultMessage,
+    default_tone: c.defaultTone,
+    context: c.context,
+  }));
+
+  return (
+    `# User profile\n${profileLines.join('\n')}` +
+    memoriesBlock +
+    `\n\n# Candidates (JSON)\n${JSON.stringify(compactCandidates, null, 2)}` +
+    `\n\nCall select_insights with the curated set. Up to ${MAX_SURFACED} entries. Zero is a valid answer if nothing is interesting.`
+  );
+}
+
+/**
+ * Run the curator. Returns the curated Insight[] (possibly empty) on
+ * success, or null if the call failed or returned malformed output.
+ * Caller should fall back to deterministic candidates on null.
+ */
+export async function curateInsights(args: CurateArgs): Promise<Insight[] | null> {
+  const logger = createLogger('insights:curator');
+
+  if (args.candidates.length === 0) return [];
+
+  const candidateById = new Map(args.candidates.map((c) => [c.id, c]));
+  const client = new Anthropic({ apiKey: args.apiKey });
+
+  let response: Anthropic.Messages.Message;
+  try {
+    response = await client.messages.create({
+      model: CURATOR_MODEL,
+      // Generous cap; tool-use payload for 3 short rewrites is well under this.
+      max_tokens: 800,
+      system: CURATOR_SYSTEM,
+      tools: [SELECT_INSIGHTS_TOOL],
+      // Force the model to call our tool — it can't free-text its way out.
+      tool_choice: { type: 'tool', name: 'select_insights' },
+      messages: [{ role: 'user', content: buildUserMessage(args) }],
+    });
+  } catch (err) {
+    logger.error('curator call failed', err as Error, {
+      candidate_count: args.candidates.length,
+    });
+    return null;
+  }
+
+  const toolUse = response.content.find(
+    (b): b is Extract<Anthropic.Messages.ContentBlock, { type: 'tool_use' }> =>
+      b.type === 'tool_use' && b.name === 'select_insights',
+  );
+  if (!toolUse) {
+    logger.warn('curator returned no tool_use block', {
+      stop_reason: response.stop_reason,
+    });
+    return null;
+  }
+
+  // Defensive parse — input is `unknown` from the SDK type.
+  const input = toolUse.input as { selected?: SelectedItem[] } | null;
+  const selected = Array.isArray(input?.selected) ? input!.selected : [];
+
+  const insights: Insight[] = [];
+  let nextPriority = 1;
+  for (const item of selected.slice(0, MAX_SURFACED)) {
+    const candidate = candidateById.get(item.candidate_id);
+    if (!candidate) {
+      // Model invented an id. Skip rather than crash; we still get
+      // partial value from the other selections.
+      logger.warn('curator referenced unknown candidate id', {
+        invented_id: item.candidate_id,
+      });
+      continue;
+    }
+    const title = typeof item.title === 'string' && item.title.trim() ? item.title.trim() : candidate.defaultTitle;
+    const message = typeof item.message === 'string' && item.message.trim() ? item.message.trim() : candidate.defaultMessage;
+    const tone =
+      item.tone === 'positive' || item.tone === 'negative' || item.tone === 'neutral'
+        ? item.tone
+        : candidate.defaultTone;
+
+    insights.push({
+      id: candidate.id,
+      title,
+      message,
+      tone,
+      priority: nextPriority++,
+      ...(candidate.feature ? { feature: candidate.feature } : {}),
+      ...(candidate.action ? { action: candidate.action } : {}),
+    });
+  }
+
+  logger.info('curator complete', {
+    candidate_count: args.candidates.length,
+    surfaced_count: insights.length,
+    input_tokens: response.usage.input_tokens,
+    output_tokens: response.usage.output_tokens,
+  });
+
+  return insights;
+}
+
+/**
+ * Deterministic fallback when the curator can't run (no API key,
+ * network failure, malformed response). Sorts by priorityHint then by
+ * tone (negative first), takes the top N, and returns Insight[] using
+ * each candidate's default copy.
+ *
+ * This is intentionally identical to the OLD behavior — so a complete
+ * curator outage degrades back to today's experience instead of an
+ * empty carousel.
+ */
+export function fallbackInsights(candidates: InsightCandidate[]): Insight[] {
+  const toneOrder: Record<'negative' | 'neutral' | 'positive', number> = {
+    negative: 0,
+    neutral: 1,
+    positive: 2,
+  };
+  const sorted = [...candidates].sort(
+    (a, b) =>
+      a.priorityHint - b.priorityHint ||
+      toneOrder[a.defaultTone] - toneOrder[b.defaultTone],
+  );
+  return sorted.slice(0, MAX_SURFACED).map((c, i) => ({
+    id: c.id,
+    title: c.defaultTitle,
+    message: c.defaultMessage,
+    tone: c.defaultTone,
+    priority: i + 1,
+    ...(c.feature ? { feature: c.feature } : {}),
+    ...(c.action ? { action: c.action } : {}),
+  }));
+}

--- a/apps/finance/src/lib/insights/generators/budgetAlert.ts
+++ b/apps/finance/src/lib/insights/generators/budgetAlert.ts
@@ -1,7 +1,8 @@
-import type { Insight } from '../types';
+import type { InsightCandidate } from '../types';
 import { formatNumber } from '../types';
 
 interface BudgetProgress {
+  id: string;
   amount: number;
   spent: number;
   remaining: number;
@@ -10,27 +11,105 @@ interface BudgetProgress {
   system_categories?: { label: string } | null;
 }
 
-export function budgetAlert(budgets: BudgetProgress[]): Insight | null {
-  if (!budgets || budgets.length === 0) return null;
+/**
+ * Category group / category names that almost always represent a fixed
+ * recurring bill paid in full once a month. The curator uses this to
+ * suppress "100% spent" alerts for these categories on day 5 — that's
+ * expected behavior, not a warning.
+ *
+ * The list is intentionally narrow. When in doubt, mark 'unknown' and
+ * let the curator look at percent_spent vs expected_pacing_percent to
+ * decide. Better to occasionally surface a fixed bill the curator
+ * downgrades than to silently swallow a real budget overrun on a
+ * miscategorized transaction.
+ */
+const FIXED_RECURRING_KEYWORDS = [
+  'mortgage',
+  'rent',
+  'rent and utilities',
+  'loan payment',
+  'loan payments',
+  'auto loan',
+  'student loan',
+  'personal loan',
+  'insurance',
+  'utilities',
+  'housing',
+];
 
-  const highest = budgets.reduce((max, b) => (b.percentage > max.percentage ? b : max), budgets[0]);
-  if (highest.percentage < 75) return null;
+function classifyCategory(name: string): 'fixed_recurring' | 'variable' | 'unknown' {
+  const lower = name.toLowerCase();
+  if (FIXED_RECURRING_KEYWORDS.some((kw) => lower.includes(kw))) {
+    return 'fixed_recurring';
+  }
+  // Common variable buckets — naming them explicitly so the curator
+  // can lean into pacing math for these without second-guessing.
+  if (
+    lower.includes('food') ||
+    lower.includes('dining') ||
+    lower.includes('restaurant') ||
+    lower.includes('coffee') ||
+    lower.includes('shopping') ||
+    lower.includes('entertainment') ||
+    lower.includes('travel') ||
+    lower.includes('personal')
+  ) {
+    return 'variable';
+  }
+  return 'unknown';
+}
 
-  const name = highest.category_groups?.name || highest.system_categories?.label || 'A budget';
+/**
+ * Emits one candidate per budget that's at >= 50% spent. The curator
+ * decides which (if any) are worth surfacing based on category_type
+ * and pacing — generators don't pre-filter on "is this obvious?".
+ *
+ * The 50% floor is just a noise cut: budgets at <50% rarely have
+ * anything for the curator to say. The curator typically picks one,
+ * not all.
+ */
+export function budgetAlertCandidates(budgets: BudgetProgress[]): InsightCandidate[] {
+  if (!budgets || budgets.length === 0) return [];
 
   const now = new Date();
   const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  const daysLeft = daysInMonth - now.getDate();
-  const daysLabel = daysLeft === 1 ? '1 day' : `${daysLeft} days`;
+  const daysIntoMonth = now.getDate();
+  const daysLeft = daysInMonth - daysIntoMonth;
+  const expectedPacing = (daysIntoMonth / daysInMonth) * 100;
 
-  const pct = Math.round(highest.percentage);
+  const candidates: InsightCandidate[] = [];
 
-  return {
-    id: 'budget-alert',
-    title: `${name} Budget`,
-    priority: 1,
-    message: `Your ${name} budget is ${formatNumber(pct)}% spent with ${daysLabel} left this month.`,
-    tone: pct >= 90 ? 'negative' : 'neutral',
-    feature: 'budgets',
-  };
+  for (const b of budgets) {
+    if (!b.percentage || b.percentage < 50) continue;
+
+    const name = b.category_groups?.name || b.system_categories?.label || 'A budget';
+    const categoryType = classifyCategory(name);
+    const pct = Math.round(b.percentage);
+    const daysLabel = daysLeft === 1 ? '1 day' : `${daysLeft} days`;
+
+    candidates.push({
+      id: `budget-status:${b.id}`,
+      kind: 'budget_status',
+      defaultTitle: `${name} Budget`,
+      defaultMessage: `Your ${name} budget is ${formatNumber(pct)}% spent with ${daysLabel} left this month.`,
+      defaultTone: pct >= 100 ? 'negative' : pct >= 90 ? 'negative' : 'neutral',
+      priorityHint: 1,
+      feature: 'budgets',
+      context: {
+        type: 'budget_status',
+        budget_id: b.id,
+        category_name: name,
+        category_type: categoryType,
+        monthly_amount: b.amount,
+        spent: b.spent,
+        percent_spent: pct,
+        remaining: b.remaining,
+        days_into_month: daysIntoMonth,
+        days_in_month: daysInMonth,
+        expected_pacing_percent: Math.round(expectedPacing),
+      },
+    });
+  }
+
+  return candidates;
 }

--- a/apps/finance/src/lib/insights/generators/spendingPace.ts
+++ b/apps/finance/src/lib/insights/generators/spendingPace.ts
@@ -1,4 +1,4 @@
-import type { Insight } from '../types';
+import type { InsightCandidate } from '../types';
 import { formatNumber } from '../types';
 
 interface SpendingPaceData {
@@ -6,32 +6,47 @@ interface SpendingPaceData {
   lastMonthSpending: number;
 }
 
-export function spendingPace(data: SpendingPaceData): Insight | null {
+/**
+ * Compares same-day-of-month spending vs last month. Emits a single
+ * candidate when there's a meaningful change. The curator decides
+ * whether the magnitude is interesting given the user's context (a
+ * 6% swing is different in a $500/month vs $5,000/month spender).
+ */
+export function spendingPaceCandidates(data: SpendingPaceData): InsightCandidate[] {
   const { currentMonthSpending, lastMonthSpending } = data;
 
-  if (lastMonthSpending === 0 && currentMonthSpending === 0) return null;
-  if (lastMonthSpending === 0) return null;
+  if (lastMonthSpending === 0 && currentMonthSpending === 0) return [];
+  if (lastMonthSpending === 0) return [];
 
   const change = ((currentMonthSpending - lastMonthSpending) / lastMonthSpending) * 100;
   const absChange = Math.abs(Math.round(change));
 
-  if (absChange < 5) return null;
+  // Floor at 5% — anything tighter than that is statistical noise on a
+  // partial month. The curator may further filter based on absolute
+  // magnitude in the user's context.
+  if (absChange < 5) return [];
 
-  if (change < 0) {
-    return {
+  const now = new Date();
+  const daysIntoMonth = now.getDate();
+
+  return [
+    {
       id: 'spending-pace',
-      title: 'Spending Pace',
-      priority: 2,
-      message: `You're spending ${formatNumber(absChange)}% less than this point last month. Nice.`,
-      tone: 'positive',
-    };
-  }
-
-  return {
-    id: 'spending-pace',
-    title: 'Spending Pace',
-    priority: 2,
-    message: `You're spending ${formatNumber(absChange)}% faster than this point last month.`,
-    tone: 'negative',
-  };
+      kind: 'spending_pace',
+      defaultTitle: 'Spending Pace',
+      defaultMessage:
+        change < 0
+          ? `You're spending ${formatNumber(absChange)}% less than this point last month. Nice.`
+          : `You're spending ${formatNumber(absChange)}% faster than this point last month.`,
+      defaultTone: change < 0 ? 'positive' : 'negative',
+      priorityHint: 2,
+      context: {
+        type: 'spending_pace',
+        current_month_spending: currentMonthSpending,
+        last_month_spending: lastMonthSpending,
+        pct_change: Math.round(change),
+        days_into_month: daysIntoMonth,
+      },
+    },
+  ];
 }

--- a/apps/finance/src/lib/insights/generators/topCategoryShift.ts
+++ b/apps/finance/src/lib/insights/generators/topCategoryShift.ts
@@ -1,4 +1,4 @@
-import type { Insight } from '../types';
+import type { InsightCandidate } from '../types';
 import { formatNumber } from '../types';
 
 interface CategoryData {
@@ -17,32 +17,52 @@ interface TopCategoryShiftData {
   months: MonthData[];
 }
 
-export function topCategoryShift(data: TopCategoryShiftData): Insight | null {
+/**
+ * Surfaces the top-spending category this month if it's notably above
+ * the user's typical per-category average. Emits up to one candidate;
+ * the curator decides if "X is high this month" beats "Y bills are
+ * upcoming" in importance.
+ */
+export function topCategoryShiftCandidates(data: TopCategoryShiftData): InsightCandidate[] {
   const { categories, months } = data;
 
-  if (!categories || categories.length === 0) return null;
+  if (!categories || categories.length === 0) return [];
 
   const priorMonths = months.filter((m) => !m.isCurrentMonth && m.isComplete);
-  if (priorMonths.length < 2) return null;
+  if (priorMonths.length < 2) return [];
 
   const avgMonthlySpending = priorMonths.reduce((s, m) => s + m.spending, 0) / priorMonths.length;
-  if (avgMonthlySpending === 0) return null;
+  if (avgMonthlySpending === 0) return [];
 
   const avgPerCategory = avgMonthlySpending / Math.max(categories.length, 1);
   const topCategory = categories[0];
 
-  if (!topCategory || topCategory.total_spent === 0) return null;
+  if (!topCategory || topCategory.total_spent === 0) return [];
 
   const ratio = topCategory.total_spent / avgPerCategory;
-  if (ratio < 1.4) return null;
+  // Lower the floor to 1.2x — let the curator decide if 30% above
+  // typical is interesting given the absolute dollars and the user's
+  // budget for this category.
+  if (ratio < 1.2) return [];
 
   const pct = Math.round((ratio - 1) * 100);
 
-  return {
-    id: 'top-category-shift',
-    title: topCategory.label,
-    priority: 4,
-    message: `${topCategory.label} spending is ${formatNumber(pct)}% higher than your typical month.`,
-    tone: 'negative',
-  };
+  return [
+    {
+      id: `category-shift:${topCategory.label}`,
+      kind: 'category_shift',
+      defaultTitle: topCategory.label,
+      defaultMessage: `${topCategory.label} spending is ${formatNumber(pct)}% higher than your typical month.`,
+      defaultTone: 'negative',
+      priorityHint: 4,
+      context: {
+        type: 'category_shift',
+        category_label: topCategory.label,
+        current_month_spent: topCategory.total_spent,
+        typical_per_category_avg: avgPerCategory,
+        ratio,
+        pct_above_typical: pct,
+      },
+    },
+  ];
 }

--- a/apps/finance/src/lib/insights/generators/upcomingBills.ts
+++ b/apps/finance/src/lib/insights/generators/upcomingBills.ts
@@ -1,4 +1,4 @@
-import type { Insight } from '../types';
+import type { InsightCandidate } from '../types';
 import { formatCurrency } from '../../formatCurrency';
 
 interface RecurringStream {
@@ -8,8 +8,14 @@ interface RecurringStream {
   merchant_name: string | null;
 }
 
-export function upcomingBills(streams: RecurringStream[]): Insight | null {
-  if (!streams || streams.length === 0) return null;
+/**
+ * Bills predicted in the next 7 days. The candidate carries the full
+ * top-N list so the curator can name a specific merchant in its
+ * rewrite ("$2,400 in bills this week, mostly the LoanDepot mortgage")
+ * instead of just quoting the count.
+ */
+export function upcomingBillsCandidates(streams: RecurringStream[]): InsightCandidate[] {
+  if (!streams || streams.length === 0) return [];
 
   const now = new Date();
   const weekFromNow = new Date(now);
@@ -24,20 +30,38 @@ export function upcomingBills(streams: RecurringStream[]): Insight | null {
     return s.predicted_next_date >= todayStr && s.predicted_next_date <= weekStr;
   });
 
-  if (upcoming.length === 0) return null;
+  if (upcoming.length === 0) return [];
 
   const total = upcoming.reduce((sum, s) => sum + Math.abs(s.average_amount || 0), 0);
   const formatted = formatCurrency(total);
-
   const count = upcoming.length;
   const billWord = count === 1 ? 'bill' : 'bills';
 
-  return {
-    id: 'upcoming-bills',
-    title: 'Upcoming Bills',
-    priority: 3,
-    message: `${count} ${billWord} totaling ${formatted} due this week.`,
-    tone: 'neutral',
-    feature: 'recurring',
-  };
+  // Top 5 by amount, normalized for the curator's narration.
+  const topItems = [...upcoming]
+    .map((s) => ({
+      merchant_name: s.merchant_name || 'Unknown',
+      amount: Math.abs(s.average_amount || 0),
+      due_date: s.predicted_next_date as string,
+    }))
+    .sort((a, b) => b.amount - a.amount)
+    .slice(0, 5);
+
+  return [
+    {
+      id: 'upcoming-bills',
+      kind: 'upcoming_bills',
+      defaultTitle: 'Upcoming Bills',
+      defaultMessage: `${count} ${billWord} totaling ${formatted} due this week.`,
+      defaultTone: 'neutral',
+      priorityHint: 3,
+      feature: 'recurring',
+      context: {
+        type: 'upcoming_bills',
+        count,
+        total,
+        top_items: topItems,
+      },
+    },
+  ];
 }

--- a/apps/finance/src/lib/insights/types.ts
+++ b/apps/finance/src/lib/insights/types.ts
@@ -19,6 +19,111 @@ export interface Insight {
   action?: InsightAction;
 }
 
+/**
+ * A signal a generator surfaced from the user's data. Candidates are
+ * the input to the curator: deterministic generators emit them with
+ * full structured context, then a single LLM pass picks 2-3 worth
+ * showing and rewrites them in plain language.
+ *
+ * Generators do NOT decide whether a candidate is interesting. They
+ * compute facts; the curator decides what's worth a human's attention.
+ * That split is the whole point of the new design — letting generators
+ * gate on "is this obvious?" was producing noise like "Mortgage budget
+ * 100% spent on day 21" because there's no way for `budgetAlert` to
+ * know mortgage is a fixed monthly bill that's *supposed* to hit 100%
+ * by day 5.
+ */
+export interface InsightCandidate {
+  /** Stable per-instance id; doubles as the carousel id when surfaced. */
+  id: string;
+  /** Generator family. The curator uses this to apply kind-specific
+   *  judgment ("budget_status for fixed bills is usually noise"). */
+  kind: InsightCandidateKind;
+  /** Default title if the curator surfaces this without rewriting. */
+  defaultTitle: string;
+  /** Default one-line message in the same shape the carousel renders
+   *  today. The curator may rewrite, but this is the deterministic
+   *  fallback if the LLM call fails. */
+  defaultMessage: string;
+  /** Default tone — curator may flip if the rewrite changes framing. */
+  defaultTone: 'positive' | 'negative' | 'neutral';
+  /** Rough priority hint (lower = higher priority); the curator
+   *  ultimately decides ordering. Used as a tiebreaker in fallback. */
+  priorityHint: number;
+  /** Tier-gating tag (matches Insight.feature). Lets the curator skip
+   *  candidates the user can't act on. */
+  feature?: string;
+  /** Optional CTA carried through when surfaced. */
+  action?: InsightAction;
+  /** Structured signal data. The curator reads this to judge
+   *  interestingness. Each kind has its own context shape — see the
+   *  union below. */
+  context: InsightCandidateContext;
+}
+
+export type InsightCandidateKind =
+  | 'budget_status'
+  | 'spending_pace'
+  | 'category_shift'
+  | 'upcoming_bills';
+
+export type InsightCandidateContext =
+  | BudgetStatusContext
+  | SpendingPaceContext
+  | CategoryShiftContext
+  | UpcomingBillsContext;
+
+/**
+ * Per-budget snapshot. category_type is the key signal that lets the
+ * curator distinguish "mortgage at 100% on day 5" (expected) from
+ * "dining at 95% on day 12" (worth flagging).
+ */
+export interface BudgetStatusContext {
+  type: 'budget_status';
+  budget_id: string;
+  category_name: string;
+  /** 'fixed_recurring' = mortgage, rent, insurance, loan payments, real
+   *  utilities (the kind of expense that's paid in full once a month or
+   *  on a known cadence). 'variable' = dining, shopping, entertainment
+   *  (where pace through the month actually matters). */
+  category_type: 'fixed_recurring' | 'variable' | 'unknown';
+  monthly_amount: number;
+  spent: number;
+  percent_spent: number;
+  remaining: number;
+  days_into_month: number;
+  days_in_month: number;
+  /** % of the month elapsed. Curator compares percent_spent against
+   *  this for variable budgets ("80% spent on day 10" = pacing 4x). */
+  expected_pacing_percent: number;
+}
+
+export interface SpendingPaceContext {
+  type: 'spending_pace';
+  current_month_spending: number;
+  last_month_spending: number;
+  /** Positive = spending more than last month (negative = less). */
+  pct_change: number;
+  days_into_month: number;
+}
+
+export interface CategoryShiftContext {
+  type: 'category_shift';
+  category_label: string;
+  current_month_spent: number;
+  typical_per_category_avg: number;
+  ratio: number;
+  pct_above_typical: number;
+}
+
+export interface UpcomingBillsContext {
+  type: 'upcoming_bills';
+  count: number;
+  total: number;
+  /** Top items by amount (capped at 5) for the curator to namecheck. */
+  top_items: Array<{ merchant_name: string; amount: number; due_date: string }>;
+}
+
 /** Format a number with commas (e.g. 18032 → "18,032") */
 export function formatNumber(n: number): string {
   return n.toLocaleString('en-US');

--- a/apps/finance/supabase/migrations/20260510172007_create_user_agent_insight_cache.sql
+++ b/apps/finance/supabase/migrations/20260510172007_create_user_agent_insight_cache.sql
@@ -1,0 +1,50 @@
+-- Cache for AI-curated dashboard insights. Generators produce
+-- candidates from the user's data on every request (cheap), but the
+-- LLM curator pass that filters + rewrites them into the 2-3 worth
+-- showing is expensive enough that we don't want to repeat it on
+-- every dashboard load.
+--
+-- Two invalidation triggers:
+--   1. expires_at — TTL on the curated set (default ~6h). Keeps the
+--      surface fresh without cost.
+--   2. candidate_fingerprint — hash of the candidate set the curator
+--      saw. If new generators emit different signals (transactions
+--      synced, budget changed), the fingerprint moves and the cache
+--      is treated as stale even within its TTL.
+--
+-- Single row per user (PK on user_id) — we only ever care about the
+-- latest curated set.
+
+create table if not exists public.user_agent_insight_cache (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  -- Curated Insight[] in the same shape the carousel renders. Stored
+  -- as JSONB so the route can return it directly without re-parsing.
+  insights jsonb not null,
+  -- SHA-256 hex of the candidate set (kind + id + sorted context keys
+  -- the curator saw). Lets us detect "underlying data changed" without
+  -- needing to re-run the curator just to compare.
+  candidate_fingerprint text not null,
+  -- The model that produced this curation; lets us invalidate cleanly
+  -- when the model is bumped without a schema change.
+  model text not null,
+  generated_at timestamptz not null default now(),
+  -- TTL. The route treats `now() > expires_at` as stale and re-curates.
+  expires_at timestamptz not null
+);
+
+create index if not exists idx_user_agent_insight_cache_expires
+  on public.user_agent_insight_cache (expires_at);
+
+comment on table public.user_agent_insight_cache is 'Per-user cache of LLM-curated dashboard insights, keyed on candidate fingerprint + TTL.';
+comment on column public.user_agent_insight_cache.candidate_fingerprint is 'SHA-256 of the candidate set the curator saw; mismatch with current candidates marks the cache stale.';
+
+alter table public.user_agent_insight_cache enable row level security;
+
+-- Service role bypasses RLS, so the dashboard route works either way.
+-- A select-own policy is here so the row is queryable by the user
+-- directly if a future client-side fetch ever needs it (mirrors how
+-- user_agent_memories is set up).
+drop policy if exists "user_agent_insight_cache_select_own" on public.user_agent_insight_cache;
+create policy "user_agent_insight_cache_select_own"
+  on public.user_agent_insight_cache for select
+  using (user_id = auth.uid());

--- a/packages/supabase/src/database.ts
+++ b/packages/supabase/src/database.ts
@@ -1151,6 +1151,33 @@ export type Database = {
         }
         Relationships: []
       }
+      user_agent_insight_cache: {
+        Row: {
+          candidate_fingerprint: string
+          expires_at: string
+          generated_at: string
+          insights: Json
+          model: string
+          user_id: string
+        }
+        Insert: {
+          candidate_fingerprint: string
+          expires_at: string
+          generated_at?: string
+          insights: Json
+          model: string
+          user_id: string
+        }
+        Update: {
+          candidate_fingerprint?: string
+          expires_at?: string
+          generated_at?: string
+          insights?: Json
+          model?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       user_agent_memories: {
         Row: {
           content: string


### PR DESCRIPTION
Generators now emit rich candidates (with category type, pacing, cadence) instead of pre-filtered insights. A Haiku 4.5 curator pass picks the 1-3 worth surfacing and rewrites them in plain language, with a deterministic top-N fallback when the LLM is unavailable.

Kills the "Mortgage budget 100% spent" noise: the curator knows fixed recurring bills hitting 100% early in the month is the calendar, not a warning. Cached per-user with 6h TTL + candidate-set fingerprint so we don't re-curate on every dashboard load.

## What changed

- `lib/insights/types.ts` — new `InsightCandidate` shape with structured per-kind context (`BudgetStatusContext`, `SpendingPaceContext`, etc).
- `lib/insights/generators/*` — refactored from "emit best insight" to "emit all candidates with rich context". `budgetAlert` now classifies each budget as `fixed_recurring | variable | unknown` based on category name.
- `lib/insights/curator.ts` — single Haiku 4.5 call with forced `select_insights` tool-use. Constrained to pick from existing candidate ids; numbers must come from candidate context.
- `lib/insights/cache.ts` — SHA-256 fingerprint of candidates + 6h TTL. Failures don't poison the cache.
- `api/dashboard/insights/route.ts` — gather candidates → fingerprint → cache check → curator → cache + return. Fallbacks: no API key → deterministic top-N; curator failure → deterministic top-N (uncached); curator returns `[]` → empty (cached).
- New table `user_agent_insight_cache` (migration `20260510172007`).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing AgentChat warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] Hit dashboard in prod and verify mortgage warning is gone
- [ ] Check curator output for a couple of users with diverse data shapes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_