### PR TITLE
feat(agent): polish tool fallback + add streaming caret

### DIFF
--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -670,6 +670,7 @@ function AgentChatInner({
                   <AssistantMessageRow
                     blocks={m.blocks}
                     onContinue={handleContinuation}
+                    streaming={isLastAssistant && sending}
                   />
                   {showStamp && nowAtMount !== null && (
                     <MessageTimestamp
@@ -862,19 +863,40 @@ function MessageTimestamp({
 function AssistantMessageRow({
   blocks,
   onContinue,
+  streaming = false,
 }: {
   blocks: Block[];
   onContinue?: (message: string) => void;
+  /** True iff this is the last assistant message AND the request is
+   *  still in flight. Used to mark the trailing text block as "live"
+   *  so it gets a blinking caret. */
+  streaming?: boolean;
 }) {
   if (blocks.length === 0) {
     return <div className="text-sm text-[var(--color-fg)]"> </div>;
   }
 
+  // The caret should only render on the LAST text block, and only when
+  // that text block is the very last block in the message (i.e. nothing
+  // else is appended after it). If the last block is a tool, no caret —
+  // the tool's own loading row already conveys "in progress".
+  const lastTextIdx = (() => {
+    for (let i = blocks.length - 1; i >= 0; i--) {
+      if (blocks[i].kind === "text") return i;
+    }
+    return -1;
+  })();
+  const lastBlockIsText = blocks[blocks.length - 1]?.kind === "text";
+
   return (
     <div className="text-sm text-[var(--color-fg)]">
       {blocks.map((b, i) =>
         b.kind === "text" ? (
-          <MarkdownText key={`t-${i}`} text={b.text} />
+          <MarkdownText
+            key={`t-${i}`}
+            text={b.text}
+            streaming={streaming && lastBlockIsText && i === lastTextIdx}
+          />
         ) : (
           <ToolWidget
             key={b.id}
@@ -887,7 +909,16 @@ function AssistantMessageRow({
   );
 }
 
-function MarkdownText({ text }: { text: string }) {
+function MarkdownText({
+  text,
+  streaming = false,
+}: {
+  text: string;
+  /** When true, append a blinking caret at the end. Set only on the
+   *  trailing text block of the active assistant message — gives the
+   *  user the "still typing" cue without re-animating every token. */
+  streaming?: boolean;
+}) {
   const html = useMemo(() => {
     if (!text) return "";
     try {
@@ -900,6 +931,7 @@ function MarkdownText({ text }: { text: string }) {
   if (!text) return null;
 
   return (
+    <>
     <div
       className="leading-relaxed
         [&>*:first-child]:mt-0 [&>*:last-child]:mb-0
@@ -919,6 +951,26 @@ function MarkdownText({ text }: { text: string }) {
         [&_h3]:text-sm [&_h3]:font-medium [&_h3]:mt-3 [&_h3]:mb-1
         [&_hr]:my-4 [&_hr]:border-[var(--color-border)]"
       dangerouslySetInnerHTML={{ __html: html }}
+    />
+    {streaming && <StreamingCaret />}
+    </>
+  );
+}
+
+/**
+ * Tiny blinking bar that sits below the streamed text while a response
+ * is still in flight. Couldn't get a true inline-with-last-word cursor
+ * without re-parsing the markdown HTML, and the chat-app convention
+ * (cursor on its own line at the end) reads fine.
+ */
+function StreamingCaret() {
+  return (
+    <motion.span
+      aria-hidden
+      className="inline-block w-[2px] h-[1em] bg-[var(--color-fg)] align-text-bottom ml-0.5"
+      initial={{ opacity: 1 }}
+      animate={{ opacity: [1, 0.2, 1] }}
+      transition={{ duration: 1, repeat: Infinity, ease: "easeInOut" }}
     />
   );
 }

--- a/apps/finance/src/components/agent/widgets/ToolWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/ToolWidget.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { FiChevronRight, FiCpu } from "react-icons/fi";
 import BudgetListWidget, { type BudgetListData } from "./BudgetListWidget";
 import TransactionListWidget, { type TransactionListData } from "./TransactionListWidget";
 import SpendingBreakdownWidget, { type SpendingBreakdownData } from "./SpendingBreakdownWidget";
@@ -225,15 +227,52 @@ function ShimmerDots() {
   );
 }
 
+/**
+ * Animated collapsible for tools that don't have a dedicated widget yet
+ * (or just for surfacing debug data the user can choose to peek at).
+ * Replaces the prior native `<details>` element so we control the
+ * expand/collapse motion and ditch the bare "Tool: <name>" prefix.
+ *
+ * Label uses TOOL_LABELS where we have one, falling back to the raw
+ * tool name so unknown tools still show *something* humanly.
+ */
 function UnknownToolFallback({ name, output }: { name: string; output: unknown }) {
+  const [open, setOpen] = useState(false);
+  const label = TOOL_LABELS[name] ?? name;
+
   return (
-    <details className="my-5 text-xs">
-      <summary className="text-[var(--color-muted)] cursor-pointer hover:text-[var(--color-fg)] transition-colors">
-        Tool: {name}
-      </summary>
-      <pre className="mt-2 px-3 py-2 rounded-md font-mono overflow-x-auto text-[11px] text-[var(--color-muted)] bg-[var(--color-surface-alt)]/40">
-        {JSON.stringify(output, null, 2)}
-      </pre>
-    </details>
+    <div className="my-5 text-xs">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="group inline-flex items-center gap-2 text-[var(--color-muted)] hover:text-[var(--color-fg)] transition-colors"
+      >
+        <FiCpu className="h-3.5 w-3.5" aria-hidden />
+        <span>{label}</span>
+        <motion.span
+          animate={{ rotate: open ? 90 : 0 }}
+          transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+          className="inline-flex"
+        >
+          <FiChevronRight className="h-3 w-3" aria-hidden />
+        </motion.span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+            className="overflow-hidden"
+          >
+            <pre className="mt-2 px-3 py-2 rounded-md font-mono overflow-x-auto text-[11px] text-[var(--color-muted)] bg-[var(--color-surface-alt)]/40">
+              {JSON.stringify(output, null, 2)}
+            </pre>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }


### PR DESCRIPTION
Two threads of polish on the chat UI.

## On the missing widgets

Investigated why the screenshot showed collapsed `▶ Tool: ...` rows. The dispatcher wiring on main is correct and the production deploy (`6f8c9f96`) has been live for ~5 hours. Most likely cause is a stale client bundle in the browser — a hard refresh (Cmd+Shift+R) should bring the new widgets in.

## `UnknownToolFallback`

- Drop the bare `Tool: <name>` prefix. Lead with a small cpu icon, follow with the friendly `TOOL_LABELS` string (falls back to the raw name only if we don't have a label).
- Replace the native `<details>` element with a framer-motion expand/collapse. Panel animates open/closed at 220ms with the same exponential-out easing as the rest of the widget animations. Chevron rotates 90° on expand.

## Streaming caret

- Thread a `streaming` prop from `AgentChat` → `AssistantMessageRow` → `MarkdownText`. True only for the trailing text block of the currently-streaming assistant message.
- While true, render a 1em-tall bar that pulses opacity 1 → 0.2 → 1 on a 1s loop right after the text. Gives the user the "still typing" cue.
- Doesn't re-animate per token (that would flicker on every `text_delta` event). The existing `TypingDots` only appears before the first token arrives, so the caret picks up cleanly from there.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing AgentChat warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] Verify caret appears at end of streaming text and disappears when response completes
- [ ] Hard-refresh /agent and confirm investment widgets render (not collapsed rows)
- [ ] Click an unknown-tool fallback row — should animate open with a chevron rotation

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_