### PR TITLE
feat(agent): ticker logos, performance sparkline, widgets after prose

### DIFF
--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -670,6 +670,7 @@ function AgentChatInner({
                   <AssistantMessageRow
                     blocks={m.blocks}
                     onContinue={handleContinuation}
+                    streaming={isLastAssistant && sending}
                   />
                   {showStamp && nowAtMount !== null && (
                     <MessageTimestamp
@@ -862,19 +863,40 @@ function MessageTimestamp({
 function AssistantMessageRow({
   blocks,
   onContinue,
+  streaming = false,
 }: {
   blocks: Block[];
   onContinue?: (message: string) => void;
+  /** True iff this is the last assistant message AND the request is
+   *  still in flight. Used to mark the trailing text block as "live"
+   *  so it gets a blinking caret. */
+  streaming?: boolean;
 }) {
   if (blocks.length === 0) {
     return <div className="text-sm text-[var(--color-fg)]"> </div>;
   }
 
+  // The caret should only render on the LAST text block, and only when
+  // that text block is the very last block in the message (i.e. nothing
+  // else is appended after it). If the last block is a tool, no caret —
+  // the tool's own loading row already conveys "in progress".
+  const lastTextIdx = (() => {
+    for (let i = blocks.length - 1; i >= 0; i--) {
+      if (blocks[i].kind === "text") return i;
+    }
+    return -1;
+  })();
+  const lastBlockIsText = blocks[blocks.length - 1]?.kind === "text";
+
   return (
     <div className="text-sm text-[var(--color-fg)]">
       {blocks.map((b, i) =>
         b.kind === "text" ? (
-          <MarkdownText key={`t-${i}`} text={b.text} />
+          <MarkdownText
+            key={`t-${i}`}
+            text={b.text}
+            streaming={streaming && lastBlockIsText && i === lastTextIdx}
+          />
         ) : (
           <ToolWidget
             key={b.id}
@@ -887,7 +909,16 @@ function AssistantMessageRow({
   );
 }
 
-function MarkdownText({ text }: { text: string }) {
+function MarkdownText({
+  text,
+  streaming = false,
+}: {
+  text: string;
+  /** When true, append a blinking caret at the end. Set only on the
+   *  trailing text block of the active assistant message — gives the
+   *  user the "still typing" cue without re-animating every token. */
+  streaming?: boolean;
+}) {
   const html = useMemo(() => {
     if (!text) return "";
     try {
@@ -900,6 +931,7 @@ function MarkdownText({ text }: { text: string }) {
   if (!text) return null;
 
   return (
+    <>
     <div
       className="leading-relaxed
         [&>*:first-child]:mt-0 [&>*:last-child]:mb-0
@@ -919,6 +951,26 @@ function MarkdownText({ text }: { text: string }) {
         [&_h3]:text-sm [&_h3]:font-medium [&_h3]:mt-3 [&_h3]:mb-1
         [&_hr]:my-4 [&_hr]:border-[var(--color-border)]"
       dangerouslySetInnerHTML={{ __html: html }}
+    />
+    {streaming && <StreamingCaret />}
+    </>
+  );
+}
+
+/**
+ * Tiny blinking bar that sits below the streamed text while a response
+ * is still in flight. Couldn't get a true inline-with-last-word cursor
+ * without re-parsing the markdown HTML, and the chat-app convention
+ * (cursor on its own line at the end) reads fine.
+ */
+function StreamingCaret() {
+  return (
+    <motion.span
+      aria-hidden
+      className="inline-block w-[2px] h-[1em] bg-[var(--color-fg)] align-text-bottom ml-0.5"
+      initial={{ opacity: 1 }}
+      animate={{ opacity: [1, 0.2, 1] }}
+      transition={{ duration: 1, repeat: Infinity, ease: "easeInOut" }}
     />
   );
 }

--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -876,35 +876,39 @@ function AssistantMessageRow({
     return <div className="text-sm text-[var(--color-fg)]"> </div>;
   }
 
-  // The caret should only render on the LAST text block, and only when
-  // that text block is the very last block in the message (i.e. nothing
-  // else is appended after it). If the last block is a tool, no caret —
-  // the tool's own loading row already conveys "in progress".
-  const lastTextIdx = (() => {
-    for (let i = blocks.length - 1; i >= 0; i--) {
-      if (blocks[i].kind === "text") return i;
-    }
-    return -1;
-  })();
+  // Split text from tools so we can render the prose response first and
+  // the data widgets after. The model emits tools-then-text in its raw
+  // turn (it has to call tools before it can summarize them), but the
+  // user-facing read is "answer first, supporting data below" — so we
+  // reorder here. Order within each kind is preserved.
+  const textBlocks: TextBlock[] = [];
+  const toolBlocks: ToolBlock[] = [];
+  for (const b of blocks) {
+    if (b.kind === "text") textBlocks.push(b);
+    else toolBlocks.push(b);
+  }
+
+  // Caret only on the very last text block, and only when the LAST
+  // block in the message (in source order) is also text — i.e. the
+  // model is actively typing prose, not waiting for a tool result.
   const lastBlockIsText = blocks[blocks.length - 1]?.kind === "text";
 
   return (
     <div className="text-sm text-[var(--color-fg)]">
-      {blocks.map((b, i) =>
-        b.kind === "text" ? (
-          <MarkdownText
-            key={`t-${i}`}
-            text={b.text}
-            streaming={streaming && lastBlockIsText && i === lastTextIdx}
-          />
-        ) : (
-          <ToolWidget
-            key={b.id}
-            tool={b as ToolBlockData}
-            onContinue={onContinue}
-          />
-        ),
-      )}
+      {textBlocks.map((b, i) => (
+        <MarkdownText
+          key={`t-${i}`}
+          text={b.text}
+          streaming={streaming && lastBlockIsText && i === textBlocks.length - 1}
+        />
+      ))}
+      {toolBlocks.map((b) => (
+        <ToolWidget
+          key={b.id}
+          tool={b as ToolBlockData}
+          onContinue={onContinue}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/finance/src/components/agent/widgets/HoldingsWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/HoldingsWidget.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { formatCurrency } from "../../../lib/formatCurrency";
 import { formatShares } from "../../../lib/formatShares";
 import { MagicItem, WidgetError, WidgetFrame, WidgetLabel } from "./primitives";
@@ -7,6 +8,7 @@ import { MagicItem, WidgetError, WidgetFrame, WidgetLabel } from "./primitives";
 type Holding = {
   ticker: string;
   name: string | null;
+  logo: string | null;
   shares: number;
   avg_cost: number;
   current_price: number;
@@ -110,7 +112,7 @@ function HoldingRow({ h }: { h: Holding }) {
   return (
     <div className="flex items-center justify-between gap-3 py-1">
       <div className="flex items-center gap-3 min-w-0">
-        <TickerBadge ticker={h.ticker} assetType={h.asset_type} />
+        <TickerBadge ticker={h.ticker} assetType={h.asset_type} logo={h.logo} />
         <div className="min-w-0">
           <div className="text-sm text-[var(--color-fg)] truncate">
             {h.ticker}
@@ -133,9 +135,35 @@ function HoldingRow({ h }: { h: Holding }) {
   );
 }
 
-function TickerBadge({ ticker, assetType }: { ticker: string; assetType: string }) {
+function TickerBadge({
+  ticker,
+  assetType,
+  logo,
+}: {
+  ticker: string;
+  assetType: string;
+  logo: string | null;
+}) {
+  // Logo URLs come from the `tickers` table. They can be hosted URLs or
+  // data: URIs; either works as an <img src>. Track failure so a broken
+  // URL falls back to the text badge instead of showing a broken
+  // image glyph.
+  const [imageFailed, setImageFailed] = useState(false);
   const isCash = assetType.toLowerCase() === "cash";
   const display = isCash ? "$" : ticker.slice(0, 3).toUpperCase();
+
+  if (logo && !imageFailed) {
+    return (
+      <img
+        src={logo}
+        alt={ticker}
+        loading="lazy"
+        onError={() => setImageFailed(true)}
+        className="w-8 h-8 rounded-full bg-[var(--color-surface-alt)] flex-shrink-0 object-cover"
+      />
+    );
+  }
+
   return (
     <div className="w-8 h-8 rounded-full flex items-center justify-center bg-[var(--color-surface-alt)] flex-shrink-0">
       <span className="text-[10px] font-semibold text-[var(--color-muted)]">

--- a/apps/finance/src/components/agent/widgets/PerformanceWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/PerformanceWidget.tsx
@@ -4,6 +4,8 @@ import { motion } from "framer-motion";
 import { formatCurrency } from "../../../lib/formatCurrency";
 import { WidgetError, WidgetFrame, WidgetLabel, useAnimate } from "./primitives";
 
+type SeriesPoint = { date: string; value: number };
+
 export type PerformanceData = {
   period?: "last_30_days" | "last_90_days" | "ytd" | "last_year";
   period_label?: string;
@@ -14,6 +16,7 @@ export type PerformanceData = {
   accounts_with_full_history?: string[];
   accounts_missing_history?: string[];
   total_portfolio_current_value?: number;
+  series?: SeriesPoint[];
   error?: string;
 };
 
@@ -47,7 +50,7 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
   const color = positive
     ? "text-[var(--color-success)]"
     : "text-[var(--color-danger)]";
-  const barColor = positive
+  const lineColor = positive
     ? "var(--color-success)"
     : "var(--color-danger)";
 
@@ -57,6 +60,8 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
     missing.length > 0 && withHistory.length > 0
       ? `Excludes ${missing.length} account${missing.length === 1 ? "" : "s"} with no history for this period.`
       : null;
+
+  const series = data.series ?? [];
 
   return (
     <WidgetFrame>
@@ -76,10 +81,7 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
         {formatCurrency(change, true)}
       </div>
 
-      {/* Start → end values, plus an animated bar that visually
-          represents the magnitude of the change relative to the start
-          value. Cap the visual range at ±50% so a wild outlier doesn't
-          stretch the bar to absurd lengths. */}
+      {/* Start → end values for context next to the headline. */}
       <div className="mt-3 flex items-baseline gap-4 text-[11px] text-[var(--color-muted)]">
         <span>
           start{" "}
@@ -95,11 +97,9 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
         </span>
       </div>
 
-      <ChangeBar
-        pct={changePct}
-        color={barColor}
-        positive={positive}
-      />
+      {series.length >= 2 ? (
+        <Sparkline series={series} color={lineColor} />
+      ) : null}
 
       {partialNote && (
         <div className="mt-3 text-[11px] text-[var(--color-muted)]">
@@ -110,53 +110,91 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
   );
 }
 
-function ChangeBar({
-  pct,
+const SPARKLINE_HEIGHT = 56;
+const SPARKLINE_PAD_Y = 4;
+
+/**
+ * Inline SVG sparkline. Uses a viewBox keyed to (series.length-1, 1) so
+ * Y maps to height regardless of the parent width — the path scales to
+ * fit. A subtle area fill behind the stroke makes the line read at a
+ * glance even on light backgrounds.
+ *
+ * Animates the stroke-dashoffset on first paint so the line draws in
+ * left-to-right, then unsets stroke-dasharray so it's not a fixed
+ * length on re-renders.
+ */
+function Sparkline({
+  series,
   color,
-  positive,
 }: {
-  pct: number;
+  series: SeriesPoint[];
   color: string;
-  positive: boolean;
 }) {
   const animate = useAnimate();
-  // Cap visual at 50% so a 200% pump doesn't blow the bar off-screen.
-  // The number above already conveys magnitude; the bar is just a
-  // direction + relative-strength glance.
-  const visual = Math.min(50, Math.abs(pct));
-  const widthPct = (visual / 50) * 50; // up to half the bar
-  const barStyle: React.CSSProperties = {
-    width: `${widthPct}%`,
-    backgroundColor: color,
-  };
+  const values = series.map((p) => p.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const drawableH = SPARKLINE_HEIGHT - SPARKLINE_PAD_Y * 2;
+
+  const points = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * 100;
+    const y =
+      SPARKLINE_PAD_Y + drawableH - ((v - min) / range) * drawableH;
+    return { x, y };
+  });
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)},${p.y.toFixed(2)}`)
+    .join(" ");
+  const areaPath =
+    `${linePath} L100,${SPARKLINE_HEIGHT} L0,${SPARKLINE_HEIGHT} Z`;
+
+  // Unique gradient id so multiple Sparklines on the same page don't
+  // collide. Includes color so positive/negative don't share an id.
+  const gradId = `agent-spark-${color.replace(/[^a-z0-9]/gi, "")}-${series.length}`;
 
   return (
-    <div className="mt-3 relative h-1 rounded-full bg-[var(--color-surface-alt)]/60 overflow-visible">
-      {/* Center tick — anchor for "no change". */}
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-px h-3 bg-[var(--color-border)]" />
-      {/* Filled segment, anchored to center, growing left or right. */}
-      {animate ? (
-        <motion.div
-          className="absolute top-0 h-full rounded-full"
-          style={{
-            ...barStyle,
-            left: positive ? "50%" : undefined,
-            right: positive ? undefined : "50%",
-          }}
-          initial={{ width: 0 }}
-          animate={{ width: `${widthPct}%` }}
-          transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
-        />
-      ) : (
-        <div
-          className="absolute top-0 h-full rounded-full"
-          style={{
-            ...barStyle,
-            left: positive ? "50%" : undefined,
-            right: positive ? undefined : "50%",
-          }}
-        />
-      )}
+    <div className="mt-3" style={{ height: SPARKLINE_HEIGHT }}>
+      <svg
+        viewBox={`0 0 100 ${SPARKLINE_HEIGHT}`}
+        preserveAspectRatio="none"
+        width="100%"
+        height={SPARKLINE_HEIGHT}
+        className="overflow-visible"
+      >
+        <defs>
+          <linearGradient id={gradId} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.18} />
+            <stop offset="100%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <path d={areaPath} fill={`url(#${gradId})`} stroke="none" />
+        {animate ? (
+          <motion.path
+            d={linePath}
+            fill="none"
+            stroke={color}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+            initial={{ pathLength: 0, opacity: 0.4 }}
+            animate={{ pathLength: 1, opacity: 1 }}
+            transition={{ duration: 0.9, ease: [0.16, 1, 0.3, 1] }}
+          />
+        ) : (
+          <path
+            d={linePath}
+            fill="none"
+            stroke={color}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+      </svg>
     </div>
   );
 }

--- a/apps/finance/src/components/agent/widgets/ToolWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/ToolWidget.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { FiChevronRight, FiCpu } from "react-icons/fi";
 import BudgetListWidget, { type BudgetListData } from "./BudgetListWidget";
 import TransactionListWidget, { type TransactionListData } from "./TransactionListWidget";
 import SpendingBreakdownWidget, { type SpendingBreakdownData } from "./SpendingBreakdownWidget";
@@ -225,15 +227,52 @@ function ShimmerDots() {
   );
 }
 
+/**
+ * Animated collapsible for tools that don't have a dedicated widget yet
+ * (or just for surfacing debug data the user can choose to peek at).
+ * Replaces the prior native `<details>` element so we control the
+ * expand/collapse motion and ditch the bare "Tool: <name>" prefix.
+ *
+ * Label uses TOOL_LABELS where we have one, falling back to the raw
+ * tool name so unknown tools still show *something* humanly.
+ */
 function UnknownToolFallback({ name, output }: { name: string; output: unknown }) {
+  const [open, setOpen] = useState(false);
+  const label = TOOL_LABELS[name] ?? name;
+
   return (
-    <details className="my-5 text-xs">
-      <summary className="text-[var(--color-muted)] cursor-pointer hover:text-[var(--color-fg)] transition-colors">
-        Tool: {name}
-      </summary>
-      <pre className="mt-2 px-3 py-2 rounded-md font-mono overflow-x-auto text-[11px] text-[var(--color-muted)] bg-[var(--color-surface-alt)]/40">
-        {JSON.stringify(output, null, 2)}
-      </pre>
-    </details>
+    <div className="my-5 text-xs">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="group inline-flex items-center gap-2 text-[var(--color-muted)] hover:text-[var(--color-fg)] transition-colors"
+      >
+        <FiCpu className="h-3.5 w-3.5" aria-hidden />
+        <span>{label}</span>
+        <motion.span
+          animate={{ rotate: open ? 90 : 0 }}
+          transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+          className="inline-flex"
+        >
+          <FiChevronRight className="h-3 w-3" aria-hidden />
+        </motion.span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+            className="overflow-hidden"
+          >
+            <pre className="mt-2 px-3 py-2 rounded-md font-mono overflow-x-auto text-[11px] text-[var(--color-muted)] bg-[var(--color-surface-alt)]/40">
+              {JSON.stringify(output, null, 2)}
+            </pre>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
   );
 }

--- a/apps/finance/src/lib/agent/tools.ts
+++ b/apps/finance/src/lib/agent/tools.ts
@@ -3445,11 +3445,13 @@ interface RawTickerMeta {
   name: string | null;
   sector: string | null;
   asset_type: string;
+  logo: string | null;
 }
 
 interface EnrichedHolding {
   ticker: string;
   name: string | null;
+  logo: string | null;
   shares: number;
   avg_cost: number;
   current_price: number;
@@ -3546,7 +3548,7 @@ async function loadEnrichedHoldings(
   if (uniqueTickers.length > 0) {
     const { data: tickersRaw } = await supabaseAdmin
       .from('tickers')
-      .select('symbol, name, sector, asset_type')
+      .select('symbol, name, sector, asset_type, logo')
       .in('symbol', uniqueTickers);
     tickerMeta = new Map(
       (tickersRaw ?? []).map((t) => [t.symbol, t as RawTickerMeta]),
@@ -3578,6 +3580,7 @@ async function loadEnrichedHoldings(
     return {
       ticker: h.ticker,
       name: meta?.name ?? null,
+      logo: meta?.logo ?? null,
       shares: Math.round(shares * 10000) / 10000,
       avg_cost: Math.round(avgCost * 100) / 100,
       current_price: Math.round(currentPrice * 100) / 100,
@@ -3866,14 +3869,29 @@ async function getInvestmentPerformance(
   // If only some accounts have history, exclude the missing ones from
   // BOTH ends so the change figure stays directly comparable.
   let endValueComparable = 0;
+  const comparableAccountIds = new Set<string>();
   for (const a of accounts) {
     if (chosenStartByAccount.has(a.id)) {
       endValueComparable += Number(a.plaid_balance_current ?? 0);
+      comparableAccountIds.add(a.id);
     }
   }
 
   const change = endValueComparable - startValue;
   const changePct = startValue > 0 ? (change / startValue) * 100 : 0;
+
+  // Daily time-series for the widget's sparkline. Pull all snapshots in
+  // [startDate, now] for the comparable accounts and forward-fill per
+  // account, then sum across accounts per day. Capped at ~60 points so
+  // longer periods (ytd, last_year) don't bloat the payload — we sample
+  // every N days where N keeps total ≤ 60.
+  const series = await buildPortfolioSeries(
+    comparableAccountIds,
+    startDate,
+    now,
+    chosenStartByAccount,
+    accounts,
+  );
 
   return {
     period,
@@ -3888,5 +3906,107 @@ async function getInvestmentPerformance(
      *  couldn't compute a change for. Useful when the user asks "how
      *  much is in there?" alongside the performance question. */
     total_portfolio_current_value: Math.round(endValue * 100) / 100,
+    series,
   };
+}
+
+/**
+ * Build a daily time-series of summed portfolio value across the given
+ * comparable accounts. Forward-fills per-account so a day without a
+ * fresh snapshot carries the previous value. Down-samples to ≤ MAX_POINTS
+ * so long windows stay payload-friendly.
+ */
+async function buildPortfolioSeries(
+  accountIds: Set<string>,
+  startDate: Date,
+  endDate: Date,
+  chosenStartByAccount: Map<string, number>,
+  accounts: { id: string; plaid_balance_current: number | null }[],
+): Promise<Array<{ date: string; value: number }>> {
+  if (accountIds.size === 0) return [];
+
+  const MAX_POINTS = 60;
+  const ids = Array.from(accountIds);
+
+  const { data: snapsRaw } = await supabaseAdmin
+    .from('account_snapshots')
+    .select('account_id, recorded_at, current_balance')
+    .in('account_id', ids)
+    .gte('recorded_at', startDate.toISOString())
+    .lte('recorded_at', endDate.toISOString())
+    .order('recorded_at', { ascending: true });
+  const snaps = snapsRaw ?? [];
+
+  // Per-account running value, seeded with the chosen "start" snapshot
+  // (so the series starts at the same start_value the headline uses).
+  const runningPerAccount = new Map<string, number>();
+  for (const id of ids) {
+    runningPerAccount.set(id, chosenStartByAccount.get(id) ?? 0);
+  }
+
+  // Snapshots grouped by ISO date (YYYY-MM-DD). If multiple snapshots
+  // exist on the same day for an account, the latest one wins because
+  // we already sorted ascending — last write per (account, date) lands
+  // in the map last.
+  const snapsByDayByAccount = new Map<string, Map<string, number>>();
+  for (const s of snaps) {
+    const dateKey = toIsoDate(new Date(s.recorded_at));
+    let dayMap = snapsByDayByAccount.get(dateKey);
+    if (!dayMap) {
+      dayMap = new Map();
+      snapsByDayByAccount.set(dateKey, dayMap);
+    }
+    dayMap.set(s.account_id, Number(s.current_balance ?? 0));
+  }
+
+  // Walk every day from startDate → endDate, forward-fill the per-
+  // account running values from snapshots, and sum.
+  const series: Array<{ date: string; value: number }> = [];
+  const cursor = new Date(startDate);
+  cursor.setHours(0, 0, 0, 0);
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+  while (cursor.getTime() <= end.getTime()) {
+    const dateKey = toIsoDate(cursor);
+    const dayMap = snapsByDayByAccount.get(dateKey);
+    if (dayMap) {
+      for (const [accId, bal] of dayMap) {
+        runningPerAccount.set(accId, bal);
+      }
+    }
+    let sum = 0;
+    for (const v of runningPerAccount.values()) sum += v;
+    series.push({ date: dateKey, value: Math.round(sum * 100) / 100 });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  // Pin the final point to today's authoritative balance so the
+  // sparkline ends exactly where the headline end_value says it does.
+  if (series.length > 0) {
+    let endSum = 0;
+    for (const a of accounts) {
+      if (accountIds.has(a.id)) {
+        endSum += Number(a.plaid_balance_current ?? 0);
+      }
+    }
+    series[series.length - 1] = {
+      date: series[series.length - 1].date,
+      value: Math.round(endSum * 100) / 100,
+    };
+  }
+
+  // Down-sample evenly. Always keep first and last so the chart starts
+  // and ends at the headline numbers.
+  if (series.length <= MAX_POINTS) return series;
+  const step = (series.length - 1) / (MAX_POINTS - 1);
+  const sampled: Array<{ date: string; value: number }> = [];
+  for (let i = 0; i < MAX_POINTS; i++) {
+    const idx = Math.min(series.length - 1, Math.round(i * step));
+    sampled.push(series[idx]);
+  }
+  return sampled;
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
Three things from the latest screenshot tied together.

## 1. Ticker logos on the holdings widget

The `tickers` table has a `logo` column populated by the Finnhub ticker-enrichment pass and the crypto-logo refresh job, but the agent widget was still rendering text-only `BTC` / `DOG` badges. Looked stranded next to the rich logos elsewhere in the app. Threaded `logo` through `getInvestmentHoldings` → `HoldingsWidget` → `TickerBadge`, rendered as an `<img>` with an `onError`-driven fallback to the existing text badge so broken URLs don't show as broken-image glyphs.

## 2. Sparkline in the performance widget

Replaced the abstract center-anchored bar with an actual time-series of daily portfolio value over the period.

The tool builds the series itself: pulls all snapshots in `[startDate, now]` for the comparable account set (the same accounts the headline change uses, so the line and the number reconcile), forward-fills per-account, sums across accounts per day, and pins the final point to today's authoritative balance. Down-samples to ≤60 points so YTD / last-year payloads stay small.

Widget renders an inline SVG with a subtle area gradient and an animated path draw on first paint (`pathLength: 0 → 1` over 900ms).

## 3. Widgets after prose, not before

Reverts commit `87ac6d8b` (natural-order rendering) for the agent chat specifically. The model emits tool calls before the summary text (it has to — it can't summarize results it hasn't seen yet), but for the reader the natural order is "answer up top, supporting widgets below". `AssistantMessageRow` now buckets text vs tools and renders text first.

The streaming caret keys off "last block in *source* order is text", so it still suppresses correctly while a tool is mid-flight.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing AgentChat warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] Ask "how are my investments?" — logos appear, performance widget shows a line, widgets render below the prose
- [ ] Performance line's start and end should match the start/now numbers in the widget header
- [ ] Holding with no `logo` in `tickers` table should fall back to text badge without breaking

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_