### PR TITLE
feat(agent): match performance widget to InvestmentsChart, strip holdings header

### DIFF
--- a/apps/finance/src/components/agent/widgets/HoldingsWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/HoldingsWidget.tsx
@@ -53,31 +53,11 @@ export default function HoldingsWidget({ data }: { data: HoldingsData }) {
     );
   }
 
-  const totals = data.totals;
-
-  // Headline: total market value on the left, aggregate unrealized
-  // gain on the right. The gain reads as a label/context for the
-  // total — no need for a separate "N holdings" line above it; the
-  // paginator footer already says "1–5 of 7".
+  // No portfolio-level headline here — total value + period delta live
+  // on the performance widget, which sits directly above this one. This
+  // widget is just the list.
   return (
     <WidgetFrame>
-      {totals ? (
-        <div className="mb-5 flex items-end justify-between gap-3">
-          <div>
-            <div className="text-2xl text-[var(--color-fg)] tabular-nums">
-              {formatCurrency(totals.market_value, true)}
-            </div>
-            <div className="text-[11px] text-[var(--color-muted)] mt-0.5">
-              cost basis {formatCurrency(totals.cost_basis, true)}
-            </div>
-          </div>
-          <GainPill
-            amount={totals.unrealized_gain}
-            pct={totals.unrealized_gain_pct}
-          />
-        </div>
-      ) : null}
-
       <PagedList
         items={holdings}
         getKey={(h) => `${h.account_id}:${h.ticker}`}
@@ -162,21 +142,6 @@ function TickerBadge({
         {display}
       </span>
     </div>
-  );
-}
-
-function GainPill({ amount, pct }: { amount: number; pct: number }) {
-  const positive = amount >= 0;
-  const color = positive
-    ? "text-[var(--color-success)]"
-    : "text-[var(--color-danger)]";
-  const sign = positive ? "+" : "";
-  return (
-    <span className={`tabular-nums ${color}`}>
-      {sign}
-      {formatCurrency(amount, true)} ({sign}
-      {pct.toFixed(1)}%)
-    </span>
   );
 }
 

--- a/apps/finance/src/components/agent/widgets/PerformanceWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/PerformanceWidget.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useId, useMemo } from "react";
+import { useId, useMemo, useState } from "react";
 import { LineChart } from "@zervo/ui";
 import { formatCurrency } from "../../../lib/formatCurrency";
-import { WidgetError, WidgetFrame, WidgetLabel } from "./primitives";
+import { WidgetError, WidgetFrame } from "./primitives";
 
 type SeriesPoint = { date: string; value: number };
 
@@ -21,20 +21,26 @@ export type PerformanceData = {
   error?: string;
 };
 
+interface ChartPoint {
+  dateString: string;
+  date: Date;
+  value: number;
+}
+
 export default function PerformanceWidget({ data }: { data: PerformanceData }) {
-  // Hooks run unconditionally before any early returns so the rules-of-
-  // hooks pass with the error branches below.
-  const chartData = useMemo(() => {
-    // Same shape InvestmentsChart hands to LineChart: dateString + value.
-    // Recharts won't render a single point as a line, so when only one
-    // historical point exists we synthesize a flat baseline 30 days back
-    // — matches the InvestmentsChart fallback.
-    const rawSeries = data.series ?? [];
-    const points = rawSeries.map((p) => ({
+  // All hooks run unconditionally before the early-return branches —
+  // rules-of-hooks.
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const chartData = useMemo<ChartPoint[]>(() => {
+    const raw = data.series ?? [];
+    const points: ChartPoint[] = raw.map((p) => ({
       dateString: p.date,
       date: new Date(p.date),
       value: p.value,
     }));
+    // Recharts needs ≥ 2 points to draw a line. If we only have one,
+    // synthesize a flat baseline 30 days back — matches InvestmentsChart.
     if (points.length === 1) {
       const earlier = new Date(points[0].date);
       earlier.setDate(earlier.getDate() - 30);
@@ -50,24 +56,24 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
     return points;
   }, [data.series]);
 
-  // useId keeps the recharts gradient defs unique even if multiple
-  // PerformanceWidgets render on the same page (different conversation
-  // turns, history). Without this they'd collide and one widget would
-  // render with another's gradient color.
+  // Stable gradient id so multiple widget instances on the page (history
+  // + new turn) don't collide on recharts shared defs.
   const gradientId = useId().replace(/:/g, "");
 
   if (data.error) {
-    // Special-case: when start data is missing entirely the tool returns
-    // an error string AND end_value. Show the end value alongside the
-    // explanation rather than just a red error pill.
+    // Special-case: tool returned an error string but still gave us
+    // end_value. Show the current portfolio with the explanation, not
+    // just a red error pill.
     if (data.end_value !== undefined) {
       return (
         <WidgetFrame>
-          <WidgetLabel left={data.period_label ?? "Performance"} />
-          <div className="text-2xl text-[var(--color-fg)] tabular-nums">
-            {formatCurrency(data.end_value, true)}
-          </div>
-          <div className="text-[11px] text-[var(--color-muted)] mt-1">
+          <Header
+            label={data.period_label ?? "Performance"}
+            currentValue={data.end_value}
+            startValue={data.end_value}
+            displayDate={null}
+          />
+          <div className="text-[11px] text-[var(--color-muted)] mt-2">
             {data.error}
           </div>
         </WidgetFrame>
@@ -76,18 +82,19 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
     return <WidgetError message={data.error} />;
   }
 
-  const startValue = data.start_value ?? 0;
-  const endValue = data.end_value ?? 0;
-  const change = data.change ?? 0;
-  const changePct = data.change_pct ?? 0;
-  const positive = change >= 0;
-  const sign = positive ? "+" : "";
-  const color = positive
-    ? "text-[var(--color-success)]"
-    : "text-[var(--color-danger)]";
-  const lineColor = positive
-    ? "var(--color-success)"
-    : "var(--color-danger)";
+  const hasChart = chartData.length >= 2;
+  // Hover resolves to whichever point recharts says is active; otherwise
+  // fall back to the most recent point so the headline shows "now".
+  const displayPoint =
+    activeIndex !== null && chartData[activeIndex]
+      ? chartData[activeIndex]
+      : chartData[chartData.length - 1];
+
+  const currentDisplayValue = displayPoint?.value ?? data.end_value ?? 0;
+  // Delta computed from the FIRST visible point in the chart, so as the
+  // user hovers earlier in the range the delta updates relative to the
+  // chart's anchor. Matches InvestmentsChart behavior.
+  const startValueForDelta = chartData[0]?.value ?? data.start_value ?? 0;
 
   const missing = data.accounts_missing_history ?? [];
   const withHistory = data.accounts_with_full_history ?? [];
@@ -96,72 +103,116 @@ export default function PerformanceWidget({ data }: { data: PerformanceData }) {
       ? `Excludes ${missing.length} account${missing.length === 1 ? "" : "s"} with no history for this period.`
       : null;
 
+  // Line color is keyed off the OVERALL trend (first to last), not the
+  // hovered delta, so the line itself doesn't flip color mid-hover.
+  const overallUp = (chartData[chartData.length - 1]?.value ?? 0) >= (chartData[0]?.value ?? 0);
+  const lineColor = overallUp
+    ? "var(--color-success)"
+    : "var(--color-danger)";
+
   return (
     <WidgetFrame>
-      <WidgetLabel
-        left={data.period_label ?? data.period ?? "Performance"}
-        right={
-          <span className={`tabular-nums ${color}`}>
-            {sign}
-            {changePct.toFixed(2)}%
-          </span>
-        }
-      />
+      <div onMouseLeave={() => setActiveIndex(null)}>
+        <Header
+          label={data.period_label ?? data.period ?? "Performance"}
+          currentValue={currentDisplayValue}
+          startValue={startValueForDelta}
+          displayDate={displayPoint?.dateString ?? null}
+          hasDelta={hasChart}
+        />
 
-      {/* Big number — the headline change in dollars. */}
-      <div className={`text-3xl tabular-nums ${color}`}>
-        {sign}
-        {formatCurrency(change, true)}
+        {hasChart ? (
+          <div className="mt-4">
+            <LineChart
+              data={chartData}
+              dataKey="value"
+              width="100%"
+              height={140}
+              margin={{ top: 8, right: 0, bottom: 8, left: 0 }}
+              strokeColor={lineColor}
+              strokeWidth={2}
+              showArea={true}
+              areaOpacity={0.15}
+              showDots={false}
+              showTooltip={false}
+              gradientId={`agentPerformanceGradient-${gradientId}`}
+              curveType="monotone"
+              animationDuration={800}
+              xAxisDataKey="dateString"
+              yAxisDomain={["dataMin", "dataMax"]}
+              onMouseMove={(_d, index) => setActiveIndex(index)}
+              onMouseLeave={() => setActiveIndex(null)}
+            />
+          </div>
+        ) : null}
+
+        {partialNote && (
+          <div className="mt-3 text-[11px] text-[var(--color-muted)]">
+            {partialNote}
+          </div>
+        )}
       </div>
-
-      {/* Start → end values for context next to the headline. */}
-      <div className="mt-3 flex items-baseline gap-4 text-[11px] text-[var(--color-muted)]">
-        <span>
-          start{" "}
-          <span className="text-[var(--color-fg)] tabular-nums">
-            {formatCurrency(startValue, true)}
-          </span>
-        </span>
-        <span>
-          now{" "}
-          <span className="text-[var(--color-fg)] tabular-nums">
-            {formatCurrency(endValue, true)}
-          </span>
-        </span>
-      </div>
-
-      {chartData.length >= 2 ? (
-        <div className="mt-4">
-          {/* Same LineChart the /investments page uses (and the net
-              worth chart on /accounts). Same gradient, same monotone
-              interpolation, same animation duration — keeps the agent
-              widget visually consistent with the rest of the app. */}
-          <LineChart
-            data={chartData}
-            dataKey="value"
-            width="100%"
-            height={140}
-            margin={{ top: 8, right: 0, bottom: 8, left: 0 }}
-            strokeColor={lineColor}
-            strokeWidth={2}
-            showArea={true}
-            areaOpacity={0.15}
-            showDots={false}
-            showTooltip={false}
-            gradientId={`agentPerformanceGradient-${gradientId}`}
-            curveType="monotone"
-            animationDuration={800}
-            xAxisDataKey="dateString"
-            yAxisDomain={["dataMin", "dataMax"]}
-          />
-        </div>
-      ) : null}
-
-      {partialNote && (
-        <div className="mt-3 text-[11px] text-[var(--color-muted)]">
-          {partialNote}
-        </div>
-      )}
     </WidgetFrame>
+  );
+}
+
+/**
+ * Header strip: uppercase period label + current/hovered value on the
+ * left, hover date on the right. Mirrors the InvestmentsChart layout
+ * exactly so the agent widget reads as the same surface as the
+ * /investments page.
+ */
+function Header({
+  label,
+  currentValue,
+  startValue,
+  displayDate,
+  hasDelta = true,
+}: {
+  label: string;
+  currentValue: number;
+  startValue: number;
+  displayDate: string | null;
+  hasDelta?: boolean;
+}) {
+  const delta = currentValue - startValue;
+  const deltaPct =
+    startValue !== 0 ? (delta / Math.abs(startValue)) * 100 : 0;
+  const positive = delta > 0;
+  const negative = delta < 0;
+  const deltaColor = positive
+    ? "text-emerald-500"
+    : negative
+      ? "text-rose-500"
+      : "text-[var(--color-muted)]";
+  const sign = positive ? "+" : "";
+
+  return (
+    <div className="flex items-start justify-between">
+      <div>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--color-muted)]">
+          {label}
+        </div>
+        <div className="mt-1 text-3xl font-medium tabular-nums text-[var(--color-fg)]">
+          {formatCurrency(currentValue, true)}
+        </div>
+        {hasDelta && (
+          <div className={`mt-1 text-xs font-medium tabular-nums ${deltaColor}`}>
+            {sign}
+            {formatCurrency(delta, true)} ({sign}
+            {deltaPct.toFixed(2)}%)
+          </div>
+        )}
+      </div>
+      <div className="text-right text-xs text-[var(--color-muted)]">
+        {displayDate
+          ? new Date(displayDate).toLocaleDateString("en-US", {
+              month: "short",
+              day: "numeric",
+              year: "numeric",
+            })
+          : ""}
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Two paired changes so the investment trio reads as one consistent surface matching `/investments`.

## Performance widget — header now matches `InvestmentsChart`

- **Headline is the current portfolio value** (or the hovered point's value), big and neutral-colored. The change in dollars + percent moves underneath as a smaller colored line. Same `text-3xl` + tabular-nums layout `InvestmentsChart` uses.
- **Hover-tracked date in the top right.** Wired recharts `onMouseMove` into a local `activeIndex` state; falls back to the most recent point when no hover.
- **Delta is computed against the first visible point**, so as you hover earlier in the range the delta updates relative to that anchor — matches `InvestmentsChart` behavior.
- Line color stays keyed off the overall (first → last) trend, so the line itself doesn't flip color mid-hover even when the hovered point is below where you started.

## Holdings widget — drop the headline strip

The total market value, cost basis, and aggregate gain pill at the top of `HoldingsWidget` were duplicating what the performance widget shows. Since the performance widget sits directly above this one (per the per-tool display priority), keeping the same numbers in both spots was just noise. `HoldingsWidget` is now just the paginated list.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing AgentChat warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] "how are my investments?" — performance widget shows total value as the headline, delta below, hover updates value + date
- [ ] Holdings widget opens straight into the paginated list
- [ ] Hover over the leftmost point — delta drops to ~0% (anchored at chart start)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_