### PR TITLE
feat(agent): pair performance + breakdown side-by-side, roomier list rows

### DIFF
--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -911,6 +911,12 @@ function AssistantMessageRow({
   // model is actively typing prose, not waiting for a tool result.
   const lastBlockIsText = blocks[blocks.length - 1]?.kind === "text";
 
+  // Group adjacent tool blocks that should render side-by-side. Right
+  // now this is just (performance + breakdown) — the chart and the
+  // allocation breakdown read well next to each other instead of
+  // stacked. Returns groups in render order; singles or pairs.
+  const toolGroups = groupTools(toolBlocks);
+
   return (
     <div className="text-sm text-[var(--color-fg)]">
       {textBlocks.map((b, i) => (
@@ -920,15 +926,83 @@ function AssistantMessageRow({
           streaming={streaming && lastBlockIsText && i === textBlocks.length - 1}
         />
       ))}
-      {toolBlocks.map((b) => (
-        <ToolWidget
-          key={b.id}
-          tool={b as ToolBlockData}
-          onContinue={onContinue}
-        />
-      ))}
+      {toolGroups.map((g) =>
+        g.kind === "pair" ? (
+          <div
+            key={g.left.id}
+            className="grid grid-cols-1 lg:grid-cols-2 gap-x-6"
+          >
+            <ToolWidget
+              tool={g.left as ToolBlockData}
+              onContinue={onContinue}
+            />
+            <ToolWidget
+              tool={g.right as ToolBlockData}
+              onContinue={onContinue}
+            />
+          </div>
+        ) : (
+          <ToolWidget
+            key={g.block.id}
+            tool={g.block as ToolBlockData}
+            onContinue={onContinue}
+          />
+        ),
+      )}
     </div>
   );
+}
+
+type ToolGroup =
+  | { kind: "single"; block: ToolBlock }
+  | { kind: "pair"; left: ToolBlock; right: ToolBlock };
+
+/**
+ * Pairs that should render side-by-side when both are present in the
+ * same assistant turn. First entry of each tuple anchors the pair's
+ * position in the render order (the second one slots in next to it).
+ */
+const SIDE_BY_SIDE_PAIRS: Array<readonly [string, string]> = [
+  ["get_investment_performance", "get_portfolio_breakdown"],
+];
+
+function groupTools(blocks: ToolBlock[]): ToolGroup[] {
+  // Find each pair-anchor block + its partner. Track which blocks are
+  // consumed by a pair so we don't render them twice.
+  const consumed = new Set<string>();
+  const partnerByAnchorId = new Map<string, ToolBlock>();
+  for (const [anchorName, partnerName] of SIDE_BY_SIDE_PAIRS) {
+    const anchor = blocks.find(
+      (b) => b.name === anchorName && !consumed.has(b.id),
+    );
+    const partner = blocks.find(
+      (b) => b.name === partnerName && !consumed.has(b.id),
+    );
+    // Only pair when BOTH have output ready. Otherwise let the singleton
+    // path render the loading row in its normal spot — pairing an
+    // unresolved tool with a resolved one would leave the pair half-
+    // empty and shift things around when the second result arrives.
+    if (anchor && partner && anchor.output && partner.output) {
+      consumed.add(anchor.id);
+      consumed.add(partner.id);
+      partnerByAnchorId.set(anchor.id, partner);
+    }
+  }
+
+  const groups: ToolGroup[] = [];
+  for (const b of blocks) {
+    const partner = partnerByAnchorId.get(b.id);
+    if (partner) {
+      groups.push({ kind: "pair", left: b, right: partner });
+    } else if (consumed.has(b.id)) {
+      // Skip — this block is the right-hand side of a pair we already
+      // emitted at the anchor's position.
+      continue;
+    } else {
+      groups.push({ kind: "single", block: b });
+    }
+  }
+  return groups;
 }
 
 function MarkdownText({

--- a/apps/finance/src/components/agent/widgets/HoldingsWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/HoldingsWidget.tsx
@@ -82,7 +82,7 @@ function HoldingRow({ h }: { h: Holding }) {
   const subtitle = subtitleParts.join(" · ");
 
   return (
-    <div className="flex items-center justify-between gap-3 py-1">
+    <div className="flex items-center justify-between gap-3 py-3.5">
       <div className="flex items-center gap-3 min-w-0">
         <TickerBadge ticker={h.ticker} assetType={h.asset_type} logo={h.logo} />
         <div className="min-w-0">

--- a/apps/finance/src/components/agent/widgets/TransactionListWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/TransactionListWidget.tsx
@@ -66,7 +66,7 @@ function TransactionRow({ tx }: { tx: Transaction }) {
   const isIncome = tx.amount > 0;
 
   return (
-    <div className="flex items-center justify-between gap-3 py-2.5">
+    <div className="flex items-center justify-between gap-3 py-3.5">
       <div className="flex items-center gap-3 min-w-0">
         <MerchantIcon
           iconUrl={tx.icon_url}


### PR DESCRIPTION
Two tweaks off the latest screenshot.

## Pair performance + breakdown side-by-side

When an assistant turn surfaces both the investment performance chart and the portfolio allocation breakdown, render them in a two-column grid (stacks on `lg`-down). Allocation next to the chart reads like the dashboard's top row instead of getting pushed below the holdings list. Holdings stays full-width below.

**Implementation**: a `SIDE_BY_SIDE_PAIRS` tuple in `AssistantMessageRow` lists anchor + partner tool names. `groupTools()` walks the (already priority-sorted) tool blocks and emits either singles or pairs at the anchor's position. Easy to extend later with more correlated pairs by adding another tuple.

Pairing only kicks in once **both** blocks have `output` ready. If one's still loading we render both as singles to avoid a half-empty pair shifting around when the second result arrives.

## Roomier list rows

Bumped per-row vertical padding in `TransactionListWidget` (`py-2.5` → `py-3.5`) and `HoldingsWidget` (`py-1` → `py-3.5`). The rows were too tight — they read clearer now and match the breathing room on the `/transactions` page.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing AgentChat warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] "how are my investments?" — performance chart and breakdown sit side-by-side on desktop, stack on narrow screens
- [ ] Mid-stream: while one of the two is still loading, both render as singles. Once both have data, they re-flow into the pair grid
- [ ] Transactions list rows feel less cramped
- [ ] Pair only triggers for the investment trio — other tool combos (e.g. budgets + transactions) keep their normal stacked layout

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_