### PR TITLE
feat(agent): donut for portfolio breakdown, extract shared InteractiveDonut

### DIFF
--- a/apps/finance/src/components/InteractiveDonut.tsx
+++ b/apps/finance/src/components/InteractiveDonut.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+/**
+ * Shared interactive donut. Lifted out of TopCategoriesCard so the
+ * agent's portfolio breakdown widget can render the same surface — same
+ * d3.arc paths, same hover bump, same center number swap. Anywhere we
+ * want "categorical breakdown as a donut", use this.
+ *
+ * Controlled by `hoveredId` + `onHover` so the caller can cross-
+ * highlight a side legend, persist hover state during external
+ * re-renders, etc. Pass `null` and a no-op if you don't need that.
+ */
+import { useEffect, useRef } from "react";
+import { arc as d3arc } from "d3-shape";
+import { CurrencyAmount } from "../lib/formatCurrency";
+
+export interface DonutSegment {
+  id: string;
+  label: string;
+  value: number;
+  color: string;
+  /** Marks this segment as the rolled-up "Other" bucket so the click
+   *  handler can branch on it without us needing to special-case the id
+   *  string. */
+  isOther?: boolean;
+  /** Original ids of categories rolled into "Other". Useful when the
+   *  consumer wants to drill into them on click. */
+  otherIds?: string[];
+}
+
+export interface InteractiveDonutProps {
+  segments: DonutSegment[];
+  total: number;
+  /** Center label when nothing is hovered (e.g. "This Month",
+   *  "By asset class"). */
+  centerLabel: string;
+  hoveredId: string | null;
+  onHover: (id: string | null) => void;
+  onClick?: (seg: DonutSegment) => void;
+  /** Outer diameter in px. Default 220 matches the dashboard. */
+  size?: number;
+  /** Ring thickness in px. */
+  strokeWidth?: number;
+  /** Small text appended after the percentage on hover, e.g.
+   *  "of spending", "of portfolio". When omitted, hovering just shows
+   *  the bare percentage like "47%". */
+  pctSuffix?: string;
+}
+
+// Defaults pulled from TopCategoriesCard so the donut on the dashboard
+// stays pixel-identical after the extraction.
+const DEFAULT_SIZE = 220;
+const DEFAULT_STROKE = 16;
+const SLICE_CORNER_RADIUS = 2;
+const SEGMENT_GAP_PX = 4;
+
+type RenderedSegment = DonutSegment & {
+  /** SVG path string for this slice (annular sector with rounded corners). */
+  path: string;
+  /** Same slice rendered with the hover-expanded outer radius. */
+  hoverPath: string;
+  pct: number;
+};
+
+// Segmented donut with a small arc gap between slices. Rendered as filled
+// `<path>`s via d3.arc rather than stroked circles with dasharray — that
+// gives us per-slice cornerRadius (slightly rounded ends, not pill caps)
+// and a true angular gap that doesn't bleed across slices.
+export default function InteractiveDonut({
+  segments,
+  total,
+  centerLabel,
+  hoveredId,
+  onHover,
+  onClick,
+  size = DEFAULT_SIZE,
+  strokeWidth = DEFAULT_STROKE,
+  pctSuffix,
+}: InteractiveDonutProps) {
+  const outerRadius = size / 2;
+  const innerRadius = outerRadius - strokeWidth;
+  // Hovered slices grow outward by 2px on each side (4px total visual
+  // bump) — same emphasis as the prior strokeWidth +4.
+  const hoverOuterRadius = outerRadius + 2;
+  const hoverInnerRadius = innerRadius - 2;
+  // padAngle wants radians; convert from the user-facing pixel gap by
+  // dividing by the mid-radius (length of arc at that radius / radius
+  // = angle in radians). Skip the gap when there's only one segment so
+  // a single full-circle ring doesn't get a visible notch.
+  const midRadius = (outerRadius + innerRadius) / 2;
+  const padAngle = segments.length > 1 ? SEGMENT_GAP_PX / midRadius : 0;
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // Track the most recent pointer type so we can distinguish a real mouse
+  // click from a touch tap. On touch, a single tap should reveal the
+  // segment's info (like a desktop hover); a second tap on the same
+  // segment then navigates.
+  const lastPointerTypeRef = useRef<string>("mouse");
+  // Defer clearing hover by a frame so moving between adjacent slices
+  // doesn't cause a flicker — the incoming slice's mouseenter cancels
+  // the pending clear.
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelClear = () => {
+    if (clearTimerRef.current) {
+      clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = null;
+    }
+  };
+  const scheduleClear = () => {
+    if (clearTimerRef.current) return;
+    clearTimerRef.current = setTimeout(() => {
+      clearTimerRef.current = null;
+      onHover(null);
+    }, 30);
+  };
+
+  useEffect(() => () => cancelClear(), []);
+
+  // Dismiss the touch-revealed tooltip when the user taps outside the donut.
+  useEffect(() => {
+    if (!hoveredId) return;
+    const handleOutside = (e: PointerEvent) => {
+      if (e.pointerType !== "touch") return;
+      const target = e.target as Node | null;
+      if (!target || !containerRef.current?.contains(target)) {
+        onHover(null);
+      }
+    };
+    document.addEventListener("pointerdown", handleOutside);
+    return () => document.removeEventListener("pointerdown", handleOutside);
+  }, [hoveredId, onHover]);
+
+  const arcGen = d3arc<{ startAngle: number; endAngle: number }>()
+    .innerRadius(innerRadius)
+    .outerRadius(outerRadius)
+    .cornerRadius(SLICE_CORNER_RADIUS)
+    .padAngle(padAngle);
+  const arcGenHover = d3arc<{ startAngle: number; endAngle: number }>()
+    .innerRadius(hoverInnerRadius)
+    .outerRadius(hoverOuterRadius)
+    .cornerRadius(SLICE_CORNER_RADIUS)
+    .padAngle(padAngle);
+
+  const rendered: RenderedSegment[] = [];
+  segments.reduce((cumulative, seg) => {
+    const pct = total > 0 ? seg.value / total : 0;
+    const angle = pct * 2 * Math.PI;
+    const startAngle = cumulative;
+    const endAngle = cumulative + angle;
+    rendered.push({
+      ...seg,
+      path: arcGen({ startAngle, endAngle }) ?? "",
+      hoverPath: arcGenHover({ startAngle, endAngle }) ?? "",
+      pct,
+    });
+    return endAngle;
+  }, 0);
+
+  const hovered = hoveredId
+    ? (rendered.find((r) => r.id === hoveredId) ?? null)
+    : null;
+
+  const centerAmount = hovered ? hovered.value : total;
+  const centerLabelText = hovered ? hovered.label : centerLabel;
+  const centerPct = hovered ? Math.round(hovered.pct * 100) : null;
+
+  const handleSegmentClick = (seg: RenderedSegment) => {
+    const isTouch = lastPointerTypeRef.current === "touch";
+    // On touch, first tap only reveals info. A subsequent tap on the
+    // already-revealed segment navigates.
+    if (isTouch && hoveredId !== seg.id) {
+      onHover(seg.id);
+      return;
+    }
+    onClick?.(seg);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} style={{ overflow: "visible" }}>
+        {/* d3.arc generates paths centered on (0, 0) starting at the
+            12 o'clock position, growing clockwise — so we translate to
+            the donut center and the angles map naturally. No -rotate-90
+            needed. */}
+        <g transform={`translate(${size / 2}, ${size / 2})`}>
+          {rendered.map((seg) => {
+            const isHovered = hoveredId === seg.id;
+            const dimmed = hoveredId && !isHovered;
+            return (
+              <path
+                key={seg.id}
+                d={isHovered ? seg.hoverPath : seg.path}
+                fill={seg.color}
+                style={{
+                  opacity: dimmed ? 0.4 : 1,
+                  cursor: onClick ? "pointer" : "default",
+                  transition: "opacity 0.15s ease, d 0.15s ease",
+                }}
+                onPointerDown={(e) => {
+                  lastPointerTypeRef.current = e.pointerType || "mouse";
+                }}
+                onMouseEnter={() => {
+                  if (lastPointerTypeRef.current === "touch") return;
+                  cancelClear();
+                  onHover(seg.id);
+                }}
+                onMouseLeave={() => {
+                  if (lastPointerTypeRef.current === "touch") return;
+                  scheduleClear();
+                }}
+                onClick={() => handleSegmentClick(seg)}
+              />
+            );
+          })}
+        </g>
+      </svg>
+
+      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none px-6 text-center">
+        <div className="text-[10px] font-medium text-[var(--color-muted)] uppercase tracking-wider truncate max-w-full">
+          {centerLabelText}
+        </div>
+        <div className="text-2xl font-medium text-[var(--color-fg)] tabular-nums leading-tight mt-1">
+          <CurrencyAmount amount={centerAmount} />
+        </div>
+        {centerPct !== null && (
+          <div className="text-[11px] tabular-nums text-[var(--color-muted)] mt-0.5">
+            {centerPct}%{pctSuffix ? ` ${pctSuffix}` : ""}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/finance/src/components/agent/widgets/PortfolioBreakdownWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/PortfolioBreakdownWidget.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { motion } from "framer-motion";
-import { formatCurrency } from "../../../lib/formatCurrency";
-import { MagicItem, WidgetError, WidgetFrame, WidgetLabel, useAnimate } from "./primitives";
+import { useState } from "react";
+import { WidgetError, WidgetFrame } from "./primitives";
+import InteractiveDonut, {
+  type DonutSegment,
+} from "../../InteractiveDonut";
 
 type Segment = {
   label: string;
@@ -63,11 +65,25 @@ const BREAKDOWN_LABEL: Record<string, string> = {
   account: "By account",
 };
 
+const PCT_SUFFIX: Record<string, string> = {
+  asset_class: "of portfolio",
+  sector: "of portfolio",
+  account: "of portfolio",
+};
+
+// Donut shrunk down from the dashboard's 220px so the widget fits
+// comfortably next to the line chart in the agent's two-column layout
+// without dominating it.
+const DONUT_SIZE = 160;
+const DONUT_STROKE = 14;
+
 export default function PortfolioBreakdownWidget({
   data,
 }: {
   data: PortfolioBreakdownData;
 }) {
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
   if (data.error) return <WidgetError message={data.error} />;
 
   const segments = data.segments ?? [];
@@ -81,88 +97,65 @@ export default function PortfolioBreakdownWidget({
 
   const breakdownBy = data.breakdown_by ?? "asset_class";
   const total = data.total ?? segments.reduce((s, x) => s + x.amount, 0);
-  const enriched = segments.map((s) => ({
-    ...s,
+
+  // Build donut segments. Use the label as the id since the upstream
+  // segments are already deduped by label.
+  const donutSegments: DonutSegment[] = segments.map((s) => ({
+    id: s.label,
+    label: s.label,
+    value: s.amount,
     color: colorFor(s.label, breakdownBy),
   }));
 
   return (
     <WidgetFrame>
-      <WidgetLabel
-        left={BREAKDOWN_LABEL[breakdownBy] ?? "Breakdown"}
-        right={formatCurrency(total, true)}
-      />
+      <div className="flex flex-col items-center gap-4">
+        <InteractiveDonut
+          segments={donutSegments}
+          total={total}
+          centerLabel={BREAKDOWN_LABEL[breakdownBy] ?? "Breakdown"}
+          hoveredId={hoveredId}
+          onHover={setHoveredId}
+          size={DONUT_SIZE}
+          strokeWidth={DONUT_STROKE}
+          pctSuffix={PCT_SUFFIX[breakdownBy] ?? "of total"}
+        />
 
-      {/* Stacked bar — same pattern as SpendingBreakdownWidget. Each
-          segment animates its width in sequence. */}
-      <div className="w-full h-1.5 rounded-full overflow-hidden bg-[var(--color-surface-alt)]/60 flex mb-4">
-        {enriched.map((s, i) => (
-          <BarSegment
-            key={s.label}
-            color={s.color}
-            percent={s.percentage}
-            index={i}
-          />
-        ))}
-      </div>
-
-      <div className="space-y-2.5">
-        {enriched.map((s, i) => (
-          <MagicItem key={s.label} index={i}>
-            <div className="flex items-center justify-between gap-3 text-xs">
-              <div className="flex items-center gap-2 min-w-0">
-                <span
-                  className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: s.color }}
-                  aria-hidden
-                />
-                <span className="text-[var(--color-fg)] truncate">{s.label}</span>
-              </div>
-              <div className="flex items-center gap-3 flex-shrink-0">
-                <span className="text-[var(--color-muted)] tabular-nums">
-                  {s.percentage.toFixed(1)}%
-                </span>
-                <span className="text-[var(--color-fg)] tabular-nums w-20 text-right">
-                  {formatCurrency(s.amount, true)}
+        {/* Tight legend below the donut. Hovering a row cross-highlights
+            the matching slice (and vice versa) — same pattern as the
+            spending donut's row list on the dashboard. */}
+        <div className="w-full space-y-1.5">
+          {donutSegments.map((s) => {
+            const pct = total > 0 ? (s.value / total) * 100 : 0;
+            const isHovered = hoveredId === s.id;
+            const dimmed = hoveredId && !isHovered;
+            return (
+              <div
+                key={s.id}
+                onMouseEnter={() => setHoveredId(s.id)}
+                onMouseLeave={() => setHoveredId(null)}
+                className="flex items-center justify-between gap-3 text-xs"
+                style={{
+                  opacity: dimmed ? 0.5 : 1,
+                  transition: "opacity 0.15s ease",
+                }}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span
+                    className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: s.color }}
+                    aria-hidden
+                  />
+                  <span className="text-[var(--color-fg)] truncate">{s.label}</span>
+                </div>
+                <span className="text-[var(--color-muted)] tabular-nums flex-shrink-0">
+                  {pct.toFixed(1)}%
                 </span>
               </div>
-            </div>
-          </MagicItem>
-        ))}
+            );
+          })}
+        </div>
       </div>
     </WidgetFrame>
-  );
-}
-
-function BarSegment({
-  color,
-  percent,
-  index,
-}: {
-  color: string;
-  percent: number;
-  index: number;
-}) {
-  const animate = useAnimate();
-  if (!animate) {
-    return (
-      <div
-        className="h-full"
-        style={{ width: `${percent}%`, backgroundColor: color }}
-      />
-    );
-  }
-  return (
-    <motion.div
-      className="h-full"
-      style={{ backgroundColor: color }}
-      initial={{ width: 0 }}
-      animate={{ width: `${percent}%` }}
-      transition={{
-        delay: 0.05 * index,
-        duration: 0.5,
-        ease: [0.16, 1, 0.3, 1],
-      }}
-    />
   );
 }

--- a/apps/finance/src/components/dashboard/TopCategoriesCard.tsx
+++ b/apps/finance/src/components/dashboard/TopCategoriesCard.tsx
@@ -1,25 +1,15 @@
 "use client";
 
-import React, { useState, useEffect, useMemo, useRef } from "react";
-import { arc as d3arc } from "d3-shape";
+import React, { useState, useEffect, useMemo } from "react";
 import { authFetch } from "../../lib/api/fetch";
 import { useUser } from "../providers/UserProvider";
 import { useRouter } from "next/navigation";
 import { CurrencyAmount } from "../../lib/formatCurrency";
 import { SegmentedTabs } from "@zervo/ui";
+import InteractiveDonut from "../InteractiveDonut";
 
 const MAX_ROWS = 5;
 const DONUT_SIZE = 220;
-const DONUT_STROKE = 16;
-// Slice corner radius. Small value because the user wanted "slight"
-// rounding — anything larger reads as a pill end. The previous
-// strokeLinecap="round" approach forced cap radius = strokeWidth/2 = 8px,
-// which was too aggressive.
-const SLICE_CORNER_RADIUS = 2;
-// Gap between slices, in pixels along the donut's mid-radius arc. Used
-// to derive padAngle for d3.arc, which inserts a uniform angular gap
-// between adjacent segments.
-const SEGMENT_GAP_PX = 4;
 // Anything under this threshold rolls into Other so every visible slice
 // has enough arc to read as a real segment (not a sliver).
 const MIN_SEGMENT_PCT = 3;
@@ -33,6 +23,7 @@ type CategoryData = {
   hex_color?: string | null;
 };
 
+// Segment shape matches `DonutSegment` from the shared component.
 type Segment = {
   id: string;
   label: string;
@@ -40,14 +31,6 @@ type Segment = {
   color: string;
   isOther?: boolean;
   otherIds?: string[];
-};
-
-type RenderedSegment = Segment & {
-  /** SVG path string for this slice (annular sector with rounded corners). */
-  path: string;
-  /** Same slice rendered with the hover-expanded outer radius. */
-  hoverPath: string;
-  pct: number;
 };
 
 type ExternalData = {
@@ -102,183 +85,6 @@ function Skeleton() {
         className="rounded-full bg-[var(--color-border)]"
         style={{ width: DONUT_SIZE, height: DONUT_SIZE }}
       />
-    </div>
-  );
-}
-
-type DonutProps = {
-  segments: Segment[];
-  total: number;
-  rangeLabel: string;
-  hoveredId: string | null;
-  onHover: (id: string | null) => void;
-  onClick?: (seg: Segment) => void;
-};
-
-// Segmented donut with a small arc gap between slices. Rendered as filled
-// `<path>`s via d3.arc rather than stroked circles with dasharray — that
-// gives us per-slice cornerRadius (slightly rounded ends, not pill caps)
-// and a true angular gap that doesn't bleed across slices.
-function InteractiveDonut({ segments, total, rangeLabel, hoveredId, onHover, onClick }: DonutProps) {
-  const outerRadius = DONUT_SIZE / 2;
-  const innerRadius = outerRadius - DONUT_STROKE;
-  // Hovered slices grow outward by 2px on each side (4px total visual
-  // bump) — same emphasis as the prior strokeWidth +4.
-  const hoverOuterRadius = outerRadius + 2;
-  const hoverInnerRadius = innerRadius - 2;
-  // padAngle wants radians; convert from the user-facing pixel gap by
-  // dividing by the mid-radius (length of arc at that radius / radius
-  // = angle in radians). Skip the gap when there's only one segment so
-  // a single full-circle ring doesn't get a visible notch.
-  const midRadius = (outerRadius + innerRadius) / 2;
-  const padAngle = segments.length > 1 ? SEGMENT_GAP_PX / midRadius : 0;
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  // Track the most recent pointer type so we can distinguish a real mouse
-  // click from a touch tap. On touch, a single tap should reveal the
-  // segment's info (like a desktop hover); a second tap on the same
-  // segment then navigates.
-  const lastPointerTypeRef = useRef<string>("mouse");
-  // Defer clearing hover by a frame so moving between adjacent slices
-  // doesn't cause a flicker — the incoming slice's mouseenter cancels
-  // the pending clear.
-  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const cancelClear = () => {
-    if (clearTimerRef.current) {
-      clearTimeout(clearTimerRef.current);
-      clearTimerRef.current = null;
-    }
-  };
-  const scheduleClear = () => {
-    if (clearTimerRef.current) return;
-    clearTimerRef.current = setTimeout(() => {
-      clearTimerRef.current = null;
-      onHover(null);
-    }, 30);
-  };
-
-  useEffect(() => () => cancelClear(), []);
-
-  // Dismiss the touch-revealed tooltip when the user taps outside the donut.
-  useEffect(() => {
-    if (!hoveredId) return;
-    const handleOutside = (e: PointerEvent) => {
-      if (e.pointerType !== "touch") return;
-      const target = e.target as Node | null;
-      if (!target || !containerRef.current?.contains(target)) {
-        onHover(null);
-      }
-    };
-    document.addEventListener("pointerdown", handleOutside);
-    return () => document.removeEventListener("pointerdown", handleOutside);
-  }, [hoveredId, onHover]);
-
-  const arcGen = d3arc<{ startAngle: number; endAngle: number }>()
-    .innerRadius(innerRadius)
-    .outerRadius(outerRadius)
-    .cornerRadius(SLICE_CORNER_RADIUS)
-    .padAngle(padAngle);
-  const arcGenHover = d3arc<{ startAngle: number; endAngle: number }>()
-    .innerRadius(hoverInnerRadius)
-    .outerRadius(hoverOuterRadius)
-    .cornerRadius(SLICE_CORNER_RADIUS)
-    .padAngle(padAngle);
-
-  const rendered: RenderedSegment[] = [];
-  segments.reduce((cumulative, seg) => {
-    const pct = total > 0 ? seg.value / total : 0;
-    const angle = pct * 2 * Math.PI;
-    const startAngle = cumulative;
-    const endAngle = cumulative + angle;
-    rendered.push({
-      ...seg,
-      path: arcGen({ startAngle, endAngle }) ?? "",
-      hoverPath: arcGenHover({ startAngle, endAngle }) ?? "",
-      pct,
-    });
-    return endAngle;
-  }, 0);
-
-  const hovered = hoveredId
-    ? rendered.find((r) => r.id === hoveredId) ?? null
-    : null;
-
-  const centerAmount = hovered ? hovered.value : total;
-  const centerLabel = hovered ? hovered.label : rangeLabel;
-  const centerPct = hovered ? Math.round(hovered.pct * 100) : null;
-
-  const handleSegmentClick = (seg: RenderedSegment) => {
-    const isTouch = lastPointerTypeRef.current === "touch";
-    // On touch, first tap only reveals info. A subsequent tap on the
-    // already-revealed segment navigates.
-    if (isTouch && hoveredId !== seg.id) {
-      onHover(seg.id);
-      return;
-    }
-    onClick?.(seg);
-  };
-
-  return (
-    <div
-      ref={containerRef}
-      className="relative"
-      style={{ width: DONUT_SIZE, height: DONUT_SIZE }}
-    >
-      <svg
-        width={DONUT_SIZE}
-        height={DONUT_SIZE}
-        style={{ overflow: "visible" }}
-      >
-        {/* d3.arc generates paths centered on (0, 0) starting at the
-            12 o'clock position, growing clockwise — so we translate to
-            the donut center and the angles map naturally. No -rotate-90
-            needed. */}
-        <g transform={`translate(${DONUT_SIZE / 2}, ${DONUT_SIZE / 2})`}>
-          {rendered.map((seg) => {
-            const isHovered = hoveredId === seg.id;
-            const dimmed = hoveredId && !isHovered;
-            return (
-              <path
-                key={seg.id}
-                d={isHovered ? seg.hoverPath : seg.path}
-                fill={seg.color}
-                style={{
-                  opacity: dimmed ? 0.4 : 1,
-                  cursor: "pointer",
-                  transition: "opacity 0.15s ease, d 0.15s ease",
-                }}
-                onPointerDown={(e) => {
-                  lastPointerTypeRef.current = e.pointerType || "mouse";
-                }}
-                onMouseEnter={() => {
-                  if (lastPointerTypeRef.current === "touch") return;
-                  cancelClear();
-                  onHover(seg.id);
-                }}
-                onMouseLeave={() => {
-                  if (lastPointerTypeRef.current === "touch") return;
-                  scheduleClear();
-                }}
-                onClick={() => handleSegmentClick(seg)}
-              />
-            );
-          })}
-        </g>
-      </svg>
-
-      <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none px-6 text-center">
-        <div className="text-[10px] font-medium text-[var(--color-muted)] uppercase tracking-wider truncate max-w-full">
-          {centerLabel}
-        </div>
-        <div className="text-2xl font-medium text-[var(--color-fg)] tabular-nums leading-tight mt-1">
-          <CurrencyAmount amount={centerAmount} />
-        </div>
-        {centerPct !== null && (
-          <div className="text-[11px] tabular-nums text-[var(--color-muted)] mt-0.5">
-            {centerPct}% of spending
-          </div>
-        )}
-      </div>
     </div>
   );
 }
@@ -432,10 +238,11 @@ export default function TopCategoriesCard({ data: externalData }: Props = {}) {
           <InteractiveDonut
             segments={segments}
             total={totalSpending}
-            rangeLabel={range.label}
+            centerLabel={range.label}
             hoveredId={hoveredId}
             onHover={setHoveredId}
             onClick={onSegmentClick}
+            pctSuffix="of spending"
           />
         </div>
       )}


### PR DESCRIPTION
The portfolio breakdown widget was visually orphaned next to the line chart in the two-column pair layout — the stacked bar takes ~50px while the chart takes ~180px+, leaving a tall column of empty space. Swap to a donut, same visuals as the dashboard's spending donut.

## Shared `InteractiveDonut`

Lifted out of `TopCategoriesCard` into `apps/finance/src/components/InteractiveDonut.tsx`. Same d3.arc paths, slice gap, rounded corners, hover-bump, dim-non-hovered, pointer-type-aware click handling (touch → first tap reveals, second tap navigates). Now driven by props:

- `size` / `strokeWidth` — defaults match the dashboard's 220 / 16
- `centerLabel` — what to show in the center when nothing is hovered
- `pctSuffix` — string appended after the percentage on hover (e.g. `"of spending"`, `"of portfolio"`). Omit for just the bare percentage.

Stays in the finance app because it depends on `d3-shape` (only listed in `apps/finance/package.json`) and `CurrencyAmount` (finance lib). Easy to promote to `@zervo/ui` later if admin needs it.

## Migrations

- `TopCategoriesCard` imports the shared donut at the same 220px size with `pctSuffix="of spending"`. Visually identical to before — the inline implementation got copied out verbatim.
- `PortfolioBreakdownWidget` swaps its stacked bar + percent legend for a 160px donut with `pctSuffix="of portfolio"`. Tight color-coded legend stays below the donut and cross-highlights on hover (same pattern as `TopCategoriesCard`'s row list).

Future categorical breakdowns (income by source, accounts by type, etc.) can use the same component.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing AgentChat warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] Dashboard `/dashboard` top-categories donut renders identically — slice gaps, hover bump, click-through to filtered transactions all work
- [ ] Agent "how are my investments?" — breakdown now renders as a donut next to the line chart, vertical sizes match
- [ ] Hover a slice → center swaps to that segment's value + "X% of portfolio"; legend row dims for non-hovered

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_