### PR TITLE
fix(agent): live prices for performance widget, compact donut layout

### DIFF
--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -928,9 +928,12 @@ function AssistantMessageRow({
       ))}
       {toolGroups.map((g) =>
         g.kind === "pair" ? (
+          // Chart gets more horizontal real estate than the donut sitting
+          // beside it. The donut's compact at 130px and reads fine in a
+          // narrower column; the chart benefits from the extra width.
           <div
             key={g.left.id}
-            className="grid grid-cols-1 lg:grid-cols-2 gap-x-6"
+            className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-x-6 items-center"
           >
             <ToolWidget
               tool={g.left as ToolBlockData}

--- a/apps/finance/src/components/agent/widgets/PortfolioBreakdownWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/PortfolioBreakdownWidget.tsx
@@ -71,11 +71,11 @@ const PCT_SUFFIX: Record<string, string> = {
   account: "of portfolio",
 };
 
-// Donut shrunk down from the dashboard's 220px so the widget fits
-// comfortably next to the line chart in the agent's two-column layout
-// without dominating it.
-const DONUT_SIZE = 160;
-const DONUT_STROKE = 14;
+// Donut shrunk down from the dashboard's 220px so the widget sits
+// compactly in the narrow column of the chart-paired layout. Smaller
+// stroke too — at 130px the dashboard's 16px ring would feel chunky.
+const DONUT_SIZE = 130;
+const DONUT_STROKE = 12;
 
 export default function PortfolioBreakdownWidget({
   data,
@@ -107,9 +107,12 @@ export default function PortfolioBreakdownWidget({
     color: colorFor(s.label, breakdownBy),
   }));
 
+  // No static legend — the center swap on hover already labels each
+  // slice. Saves vertical space and matches the dashboard's spending
+  // donut, which also leans on hover for per-slice detail.
   return (
     <WidgetFrame>
-      <div className="flex flex-col items-center gap-4">
+      <div className="flex items-center justify-center">
         <InteractiveDonut
           segments={donutSegments}
           total={total}
@@ -120,41 +123,6 @@ export default function PortfolioBreakdownWidget({
           strokeWidth={DONUT_STROKE}
           pctSuffix={PCT_SUFFIX[breakdownBy] ?? "of total"}
         />
-
-        {/* Tight legend below the donut. Hovering a row cross-highlights
-            the matching slice (and vice versa) — same pattern as the
-            spending donut's row list on the dashboard. */}
-        <div className="w-full space-y-1.5">
-          {donutSegments.map((s) => {
-            const pct = total > 0 ? (s.value / total) * 100 : 0;
-            const isHovered = hoveredId === s.id;
-            const dimmed = hoveredId && !isHovered;
-            return (
-              <div
-                key={s.id}
-                onMouseEnter={() => setHoveredId(s.id)}
-                onMouseLeave={() => setHoveredId(null)}
-                className="flex items-center justify-between gap-3 text-xs"
-                style={{
-                  opacity: dimmed ? 0.5 : 1,
-                  transition: "opacity 0.15s ease",
-                }}
-              >
-                <div className="flex items-center gap-2 min-w-0">
-                  <span
-                    className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: s.color }}
-                    aria-hidden
-                  />
-                  <span className="text-[var(--color-fg)] truncate">{s.label}</span>
-                </div>
-                <span className="text-[var(--color-muted)] tabular-nums flex-shrink-0">
-                  {pct.toFixed(1)}%
-                </span>
-              </div>
-            );
-          })}
-        </div>
       </div>
     </WidgetFrame>
   );

--- a/apps/finance/src/lib/agent/tools.ts
+++ b/apps/finance/src/lib/agent/tools.ts
@@ -3790,8 +3790,31 @@ async function getInvestmentPerformance(
   }
 
   const accountIds = accounts.map((a) => a.id);
+
+  // Build per-account live "now" value: sum of (shares × live price)
+  // across the account's holdings, falling back to plaid_balance_current
+  // when the holdings sum is short of it (covers brokerages that hold
+  // cash without exposing it as a holding row). Same convention the
+  // /investments page and the holdings widget use, so the headline
+  // here matches what the user sees there — not the staler
+  // plaid_balance_current alone.
+  const enriched = await loadEnrichedHoldings(userId);
+  const holdingsByAccount = new Map<string, number>();
+  for (const h of enriched.holdings) {
+    holdingsByAccount.set(
+      h.account_id,
+      (holdingsByAccount.get(h.account_id) ?? 0) + h.market_value,
+    );
+  }
+  const liveValueByAccount = new Map<string, number>();
+  for (const a of accounts) {
+    const fromHoldings = holdingsByAccount.get(a.id) ?? 0;
+    const fromPlaid = Number(a.plaid_balance_current ?? 0);
+    liveValueByAccount.set(a.id, Math.max(fromHoldings, fromPlaid));
+  }
+
   const endValue = accounts.reduce(
-    (s, a) => s + Number(a.plaid_balance_current ?? 0),
+    (s, a) => s + (liveValueByAccount.get(a.id) ?? 0),
     0,
   );
 
@@ -3855,7 +3878,9 @@ async function getInvestmentPerformance(
   }
 
   // If every account is missing start data, performance is undefined.
-  // Surface the gap rather than returning a misleading zero.
+  // Surface the gap rather than returning a misleading zero. end_value
+  // here is the live total across ALL accounts, since none have a
+  // comparable start.
   if (accountsWithHistory.length === 0) {
     return {
       period,
@@ -3867,12 +3892,14 @@ async function getInvestmentPerformance(
   }
 
   // If only some accounts have history, exclude the missing ones from
-  // BOTH ends so the change figure stays directly comparable.
+  // BOTH ends so the change figure stays directly comparable. End value
+  // uses the live per-account total (matches /investments + holdings
+  // widget) instead of the staler plaid_balance_current.
   let endValueComparable = 0;
   const comparableAccountIds = new Set<string>();
   for (const a of accounts) {
     if (chosenStartByAccount.has(a.id)) {
-      endValueComparable += Number(a.plaid_balance_current ?? 0);
+      endValueComparable += liveValueByAccount.get(a.id) ?? 0;
       comparableAccountIds.add(a.id);
     }
   }
@@ -3884,13 +3911,15 @@ async function getInvestmentPerformance(
   // [startDate, now] for the comparable accounts and forward-fill per
   // account, then sum across accounts per day. Capped at ~60 points so
   // longer periods (ytd, last_year) don't bloat the payload — we sample
-  // every N days where N keeps total ≤ 60.
+  // every N days where N keeps total ≤ 60. Final point is pinned to the
+  // live total (not plaid_balance_current) so the chart's right edge
+  // matches the headline.
   const series = await buildPortfolioSeries(
     comparableAccountIds,
     startDate,
     now,
     chosenStartByAccount,
-    accounts,
+    liveValueByAccount,
   );
 
   return {
@@ -3921,7 +3950,7 @@ async function buildPortfolioSeries(
   startDate: Date,
   endDate: Date,
   chosenStartByAccount: Map<string, number>,
-  accounts: { id: string; plaid_balance_current: number | null }[],
+  liveValueByAccount: Map<string, number>,
 ): Promise<Array<{ date: string; value: number }>> {
   if (accountIds.size === 0) return [];
 
@@ -3980,14 +4009,12 @@ async function buildPortfolioSeries(
     cursor.setDate(cursor.getDate() + 1);
   }
 
-  // Pin the final point to today's authoritative balance so the
-  // sparkline ends exactly where the headline end_value says it does.
+  // Pin the final point to today's live total so the sparkline ends
+  // exactly where the headline end_value says it does.
   if (series.length > 0) {
     let endSum = 0;
-    for (const a of accounts) {
-      if (accountIds.has(a.id)) {
-        endSum += Number(a.plaid_balance_current ?? 0);
-      }
+    for (const id of accountIds) {
+      endSum += liveValueByAccount.get(id) ?? 0;
     }
     series[series.length - 1] = {
       date: series[series.length - 1].date,


### PR DESCRIPTION
Three tied changes off the latest screenshot.

## Live prices in the performance widget

The widget was reading "now" from `accounts.plaid_balance_current` — that field can lag the real portfolio value by hours when Plaid hasn't synced recently. In the screenshot the widget showed `$6,582.59` while the holdings widget right next to it showed `$7,134` (the live price total).

The `/investments` page and the holdings widget both compute per-account value as `max(sum_of_holdings_at_live_price, plaid_balance_current)` — picks up live ticker movement while still respecting uncategorized cash sitting in the brokerage. Performance now uses the same math: calls `loadEnrichedHoldings()` (the holdings widget already does, hits the shared quote cache so no extra Yahoo round-trip), sums per-account live values across the comparable account set, and pins the sparkline's final point to that total. The chart's right edge now matches the holdings widget total.

## Drop the static legend under the donut

The donut already swaps its center to `label / value / "X% of portfolio"` on hover, so the legend below was redundant and stretched the widget taller than the chart sitting beside it.

## Reweight the chart-paired layout

`grid-cols-1 lg:grid-cols-2` → `lg:grid-cols-[2fr_1fr]`. Chart gets the wider column, donut shrinks to 130px (was 160px) with a 12px ring (was 14px). The pair now reads as one balanced row instead of "tall chart squished against oversized donut".

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing AgentChat warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] "how are my investments?" — performance widget headline matches what the holdings widget shows
- [ ] Sparkline's right edge = the headline value
- [ ] Breakdown donut shows in the right column at ~130px without the legend; hovering a slice shows label + value + percent in the center
- [ ] Pair grid: chart wider than donut on `lg`+, stacked on smaller

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_