### PR TITLE
fix(agent): bump breakdown donut to 180px so center text fits

### DIFF
--- a/apps/finance/src/components/agent/widgets/PortfolioBreakdownWidget.tsx
+++ b/apps/finance/src/components/agent/widgets/PortfolioBreakdownWidget.tsx
@@ -71,10 +71,15 @@ const PCT_SUFFIX: Record<string, string> = {
   account: "of portfolio",
 };
 
-// Donut shrunk down from the dashboard's 220px so the widget sits
-// compactly in the narrow column of the chart-paired layout. Smaller
-// stroke too — at 130px the dashboard's 16px ring would feel chunky.
-const DONUT_SIZE = 130;
+// Donut size chosen so the center text (label + total + hovered pct)
+// has comfortable room from the inner ring. The shared component's
+// fixed px-6 (48px total horizontal padding) eats into the inner
+// diameter; at 180/12 the inner diameter is 156px, so text gets
+// ~108px to render in — fits "BY ASSET CLASS" and the dollar total
+// without truncation or crowding the ring. Smaller diameters
+// (we tried 130) cropped the label and squashed the value into the
+// stroke.
+const DONUT_SIZE = 180;
 const DONUT_STROKE = 12;
 
 export default function PortfolioBreakdownWidget({


### PR DESCRIPTION
At 130px the inner diameter (106px) minus the shared component's hardcoded `px-6` (48px) left only ~58px of horizontal room for the center text. "BY ASSET CLASS" truncated to "BY ASSET CLA…" and the `$` total crowded against the ring stroke.

Bumping to 180px gives 108px of inner text width — enough for the uppercase label and the total without truncation, and ~48px of vertical clearance between the centered text stack and the ring on each side makes the center finally breathe. Stroke stays at 12px so the ring doesn't dominate the still-smaller-than-dashboard donut.

No changes to the shared `InteractiveDonut` — same component still powers the dashboard's spending donut at 220/16.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] "how are my investments?" — donut label reads "BY ASSET CLASS" in full, total has visible margin from the ring
- [ ] Hover a slice → label + value swap, "X% of portfolio" line fits without wrap
- [ ] Dashboard `/dashboard` spending donut still 220px, unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_