### PR TITLE
fix(agent): use container queries for pair grid so it stops wrapping with the viewport

### DIFF
--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -928,21 +928,25 @@ function AssistantMessageRow({
       ))}
       {toolGroups.map((g) =>
         g.kind === "pair" ? (
-          // Chart gets more horizontal real estate than the donut sitting
-          // beside it. The donut's compact at 130px and reads fine in a
-          // narrower column; the chart benefits from the extra width.
-          <div
-            key={g.left.id}
-            className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-x-6 items-center"
-          >
-            <ToolWidget
-              tool={g.left as ToolBlockData}
-              onContinue={onContinue}
-            />
-            <ToolWidget
-              tool={g.right as ToolBlockData}
-              onContinue={onContinue}
-            />
+          // Container query, not viewport query. The chat is in a
+          // max-w-2xl column that's the same width whether the browser
+          // window is 1100px or 1500px wide — using `lg:` (a viewport
+          // breakpoint) wrapped the pair to one column whenever the
+          // window dipped below 1024, even though the column had plenty
+          // of room. @container + @xl flips on the side-by-side layout
+          // based on the chat column's own width instead. Chart gets
+          // 2fr, donut 1fr.
+          <div key={g.left.id} className="@container">
+            <div className="grid grid-cols-1 @xl:grid-cols-[2fr_1fr] gap-x-6 items-center">
+              <ToolWidget
+                tool={g.left as ToolBlockData}
+                onContinue={onContinue}
+              />
+              <ToolWidget
+                tool={g.right as ToolBlockData}
+                onContinue={onContinue}
+              />
+            </div>
           </div>
         ) : (
           <ToolWidget


### PR DESCRIPTION
The pair grid was keyed off Tailwind's `lg:` breakpoint (viewport ≥ 1024px). The chat column is `max-w-2xl`, capped at 672px wide regardless of how big the browser window is — so dropping the window below 1024px wrapped the pair to one column even though the column itself still had plenty of room.

Switch to container queries: wrap the grid in `@container` and key the two-column layout off `@xl` (container width ≥ 576px). The layout now flips based on the chat column's own width, which is the dimension that actually matters here.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] Resize browser between 1500px and 800px — pair stays side-by-side; chat column width unchanged
- [ ] Narrow to genuinely small screens (≤ ~500px container width) — pair stacks vertically as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_