### PR TITLE
fix(agent): stop scrolling the page to the bottom when the overlay opens

### DIFF
--- a/apps/finance/src/components/agent/AgentChat.tsx
+++ b/apps/finance/src/components/agent/AgentChat.tsx
@@ -344,14 +344,21 @@ function AgentChatInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, initialMessage]);
 
-  // Auto-scroll on new content. The overlay is the scroll context here.
+  // Auto-scroll the chat to the bottom on new content.
+  //
+  // We intentionally only touch the in-overlay scroll container. The
+  // previous fallback `window.scrollTo(0, scrollHeight)` was a legacy
+  // holdover from when AgentChat could mount as a standalone page —
+  // it fired on every render where the welcome screen was showing
+  // (no `#agent-overlay-scroll` in the DOM yet), scrolling the page
+  // underneath to its bottom right before AgentOverlayProvider's
+  // body-scroll lock kicked in. The lock then froze the body at the
+  // bottom and the user landed there when the overlay closed.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const el = document.getElementById("agent-overlay-scroll");
     if (el) {
       el.scrollTop = el.scrollHeight;
-    } else {
-      window.scrollTo(0, document.documentElement.scrollHeight);
     }
   }, [messages, sending]);
 


### PR DESCRIPTION
## Root cause

Both reported behaviors trace to one line: `AgentChat.tsx`'s auto-scroll effect was falling back to

```ts
window.scrollTo(0, document.documentElement.scrollHeight);
```

whenever the in-overlay scroll container (`#agent-overlay-scroll`) wasn't in the DOM. That's exactly the case on the welcome screen, which is what every fresh overlay open shows before the user sends a message.

The order of effects on open is:

1. `AgentChat` mounts. Its auto-scroll effect runs first (child effects fire before parent effects). `#agent-overlay-scroll` doesn't exist yet (no messages), so the fallback fires → body scrolls to its bottom.
2. `AgentOverlayProvider`'s scroll-lock effect runs next → sets `body { overflow: hidden }`. The body is now frozen at the bottom.

That explains:
- "The main app underneath is still scrollable" — actually it isn't, but the lock kicks in *after* the page has been violently scrolled to the bottom, so it looks broken.
- "When I close the overlay I'm scrolled to the bottom of the page" — the lock doesn't restore the original scroll position; it just freezes whatever was there.

## Fix

Drop the `else` branch. `AgentChat` is only ever mounted inside `AgentOverlay` (no standalone `/agent` page anymore), so the in-overlay container is always the right scroll target when there are messages to scroll past. Welcome screen has nothing to scroll, so the effect should be a no-op there — which is what removing the fallback gives us.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (pre-existing warnings only)
- [x] `pnpm test` 385/385 pass
- [ ] Scroll down on dashboard, open overlay → page underneath stays at its current scroll position (no jump to bottom)
- [ ] Close overlay → you're back where you were on the page
- [ ] Open overlay with existing conversation → chat is auto-scrolled to most recent message (unchanged behavior)
- [ ] Send a message → chat auto-scrolls to bottom as new content streams in (unchanged behavior)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dhu1A9CL6TyR7Qu2pGw8M1)_